### PR TITLE
Issues during block sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.1.0"
 dependencies = [
  "account-db",
  "common-types",
- "derive_more",
+ "derive_more 0.99.3",
  "ethereum-types",
  "hash-db",
  "journaldb",
@@ -171,7 +171,7 @@ dependencies = [
  "block-reward",
  "client-traits",
  "common-types",
- "derive_more",
+ "derive_more 0.99.3",
  "engine",
  "env_logger 0.6.2",
  "ethabi",
@@ -642,7 +642,7 @@ dependencies = [
 name = "common-types"
 version = "0.1.0"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.3",
  "ethbloom",
  "ethcore-io",
  "ethereum-types",
@@ -852,6 +852,18 @@ checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
 dependencies = [
  "nix",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "rustc_version",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -1334,7 +1346,7 @@ dependencies = [
  "bincode",
  "client-traits",
  "common-types",
- "derive_more",
+ "derive_more 0.99.3",
  "engine",
  "ethcore",
  "ethcore-blockchain",
@@ -1431,7 +1443,7 @@ name = "ethcore-network"
 version = "1.12.0"
 dependencies = [
  "assert_matches",
- "derive_more",
+ "derive_more 0.99.3",
  "ethcore-io",
  "ethereum-types",
  "ipnetwork",
@@ -1489,7 +1501,7 @@ dependencies = [
  "account-state",
  "client-traits",
  "common-types",
- "derive_more",
+ "derive_more 0.99.3",
  "env_logger 0.5.13",
  "ethabi",
  "ethabi-contract",
@@ -1577,6 +1589,7 @@ version = "1.12.0"
 dependencies = [
  "client-traits",
  "common-types",
+ "derive_more 0.14.1",
  "engine",
  "enum-primitive-derive",
  "env_logger 0.5.13",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.1.0"
 dependencies = [
  "account-db",
  "common-types",
- "derive_more 0.99.3",
+ "derive_more",
  "ethereum-types",
  "hash-db",
  "journaldb",
@@ -171,7 +171,7 @@ dependencies = [
  "block-reward",
  "client-traits",
  "common-types",
- "derive_more 0.99.3",
+ "derive_more",
  "engine",
  "env_logger 0.6.2",
  "ethabi",
@@ -642,7 +642,7 @@ dependencies = [
 name = "common-types"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.3",
+ "derive_more",
  "ethbloom",
  "ethcore-io",
  "ethereum-types",
@@ -852,18 +852,6 @@ checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
 dependencies = [
  "nix",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "rustc_version",
- "syn 0.15.44",
 ]
 
 [[package]]
@@ -1346,7 +1334,7 @@ dependencies = [
  "bincode",
  "client-traits",
  "common-types",
- "derive_more 0.99.3",
+ "derive_more",
  "engine",
  "ethcore",
  "ethcore-blockchain",
@@ -1443,7 +1431,7 @@ name = "ethcore-network"
 version = "1.12.0"
 dependencies = [
  "assert_matches",
- "derive_more 0.99.3",
+ "derive_more",
  "ethcore-io",
  "ethereum-types",
  "ipnetwork",
@@ -1501,7 +1489,7 @@ dependencies = [
  "account-state",
  "client-traits",
  "common-types",
- "derive_more 0.99.3",
+ "derive_more",
  "env_logger 0.5.13",
  "ethabi",
  "ethabi-contract",
@@ -1589,7 +1577,7 @@ version = "1.12.0"
 dependencies = [
  "client-traits",
  "common-types",
- "derive_more 0.14.1",
+ "derive_more",
  "engine",
  "enum-primitive-derive",
  "env_logger 0.5.13",

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -402,8 +402,8 @@ pub trait BlockChainClient:
 	/// block with the given gas and nonce parameters.
 	fn transact(&self, tx_request: TransactionRequest) -> Result<(), transaction::Error>;
 	
-	/// Process possible blocks with fork, this method will wait for its processing on block import mutex
-	fn process_fork(&self);
+	/// Returns true, if underlying import queue is processing possible fork at the moment
+	fn is_processing_fork(&self) -> bool;
 }
 
 /// The data required for a `Client` to create a transaction.

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -401,6 +401,9 @@ pub trait BlockChainClient:
 	/// Schedule state-altering transaction to be executed on the next pending
 	/// block with the given gas and nonce parameters.
 	fn transact(&self, tx_request: TransactionRequest) -> Result<(), transaction::Error>;
+	
+	/// Process possible blocks with fork, this method will wait for its processing on block import mutex
+	fn process_fork(&self);
 }
 
 /// The data required for a `Client` to create a transaction.

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1764,6 +1764,14 @@ impl BlockChainClient for Client {
 		}
 	}
 
+	fn process_fork(&self) {
+		if self.importer.block_queue.processing_fork(&self.chain.read().best_block_hash()) {
+			debug!(target: "client", "Waiting for fork processing");
+			let _import_lock = self.importer.import_lock.lock();
+			debug!(target: "client", "Fork processing completed");
+		}
+	}
+
 	fn block_total_difficulty(&self, id: BlockId) -> Option<U256> {
 		let chain = self.chain.read();
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1766,7 +1766,7 @@ impl BlockChainClient for Client {
 
 	fn is_processing_fork(&self) -> bool {
 		let chain = self.chain.read();
-		self.importer.block_queue.is_processing_fork(&chain.best_block_hash())
+		self.importer.block_queue.is_processing_fork(&chain.best_block_hash(), &chain)
 	}
 
 	fn block_total_difficulty(&self, id: BlockId) -> Option<U256> {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1766,7 +1766,7 @@ impl BlockChainClient for Client {
 
 	fn is_processing_fork(&self) -> bool {
 		let chain = self.chain.read();
-		self.importer.block_queue.is_processing_fork(&chain.best_block_hash(), &chain)
+		self.importer.block_queue.is_processing_fork(&chain.best_block_hash())
 	}
 
 	fn block_total_difficulty(&self, id: BlockId) -> Option<U256> {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1765,7 +1765,8 @@ impl BlockChainClient for Client {
 	}
 
 	fn process_fork(&self) {
-		if self.importer.block_queue.processing_fork(&self.chain.read().best_block_hash()) {
+		let chain = self.chain.read();
+		if self.importer.block_queue.is_processing_fork(&chain.best_block_hash(), &chain) {
 			debug!(target: "client", "Waiting for fork processing");
 			let _import_lock = self.importer.import_lock.lock();
 			debug!(target: "client", "Fork processing completed");

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1764,15 +1764,9 @@ impl BlockChainClient for Client {
 		}
 	}
 
-	fn process_fork(&self) {
+	fn is_processing_fork(&self) -> bool {
 		let chain = self.chain.read();
-		while self.importer.block_queue.is_processing() {
-			if self.importer.block_queue.is_processing_fork(&chain.best_block_hash(), &chain) {
-				debug!(target: "client", "Waiting for fork processing");
-				let _import_lock = self.importer.import_lock.lock();
-				debug!(target: "client", "Fork processing completed");
-			}
-		}
+		self.importer.block_queue.is_processing_fork(&chain.best_block_hash(), &chain)
 	}
 
 	fn block_total_difficulty(&self, id: BlockId) -> Option<U256> {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1766,10 +1766,12 @@ impl BlockChainClient for Client {
 
 	fn process_fork(&self) {
 		let chain = self.chain.read();
-		if self.importer.block_queue.is_processing_fork(&chain.best_block_hash(), &chain) {
-			debug!(target: "client", "Waiting for fork processing");
-			let _import_lock = self.importer.import_lock.lock();
-			debug!(target: "client", "Fork processing completed");
+		while self.importer.block_queue.is_processing() {
+			if self.importer.block_queue.is_processing_fork(&chain.best_block_hash(), &chain) {
+				debug!(target: "client", "Waiting for fork processing");
+				let _import_lock = self.importer.import_lock.lock();
+				debug!(target: "client", "Fork processing completed");
+			}
 		}
 	}
 

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -810,6 +810,8 @@ impl BlockChainClient for TestBlockChainClient {
 		}
 	}
 
+	fn process_fork(&self) {}
+
 	// works only if blocks are one after another 1 -> 2 -> 3
 	fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {
 		Some(TreeRoute {

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -810,7 +810,7 @@ impl BlockChainClient for TestBlockChainClient {
 		}
 	}
 
-	fn process_fork(&self) {}
+	fn is_processing_fork(&self) -> bool { false }
 
 	// works only if blocks are one after another 1 -> 2 -> 3
 	fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -14,7 +14,7 @@ client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
 devp2p = { package = "ethcore-network-devp2p", path = "../../util/network-devp2p" }
 derive_more = "0.99"
-enum_primitive = "0.2"
+enum-primitive-derive = "0.2"
 ethcore-io = { path = "../../util/io" }
 ethcore-private-tx = { path = "../private-tx" }
 ethereum-forkid = "0.2"

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -13,7 +13,8 @@ bytes = { package = "parity-bytes", version = "0.1" }
 client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
 devp2p = { package = "ethcore-network-devp2p", path = "../../util/network-devp2p" }
-enum-primitive-derive = "0.2"
+derive_more = "0.14.0"
+enum_primitive = "0.2"
 ethcore-io = { path = "../../util/io" }
 ethcore-private-tx = { path = "../private-tx" }
 ethereum-forkid = "0.2"

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { package = "parity-bytes", version = "0.1" }
 client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
 devp2p = { package = "ethcore-network-devp2p", path = "../../util/network-devp2p" }
-derive_more = "0.14.0"
+derive_more = "0.99"
 enum_primitive = "0.2"
 ethcore-io = { path = "../../util/io" }
 ethcore-private-tx = { path = "../private-tx" }

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -490,7 +490,7 @@ impl NetworkProtocolHandler for SyncProtocolHandler {
 			io.register_timer(MAINTAIN_SYNC_TIMER, Duration::from_millis(1100)).expect("Error registering sync timer");
 			io.register_timer(CONTINUE_SYNC_TIMER, Duration::from_millis(2500)).expect("Error registering sync timer");
 			io.register_timer(TX_TIMER, Duration::from_millis(1300)).expect("Error registering transactions timer");
-			io.register_timer(DELAYED_PROCESSING_TIMER, Duration::from_millis(2000)).expect("Error registering delayed processing timer");
+			io.register_timer(DELAYED_PROCESSING_TIMER, Duration::from_millis(2100)).expect("Error registering delayed processing timer");
 
 			io.register_timer(PRIORITY_TIMER, PRIORITY_TIMER_INTERVAL).expect("Error registering peers timer");
 		}

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -466,6 +466,7 @@ const MAINTAIN_SYNC_TIMER: TimerToken = 1;
 const CONTINUE_SYNC_TIMER: TimerToken = 2;
 const TX_TIMER: TimerToken = 3;
 const PRIORITY_TIMER: TimerToken = 4;
+const DELAYED_PROCESSING_TIMER: TimerToken = 5;
 
 pub(crate) const PRIORITY_TIMER_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -489,6 +490,7 @@ impl NetworkProtocolHandler for SyncProtocolHandler {
 			io.register_timer(MAINTAIN_SYNC_TIMER, Duration::from_millis(1100)).expect("Error registering sync timer");
 			io.register_timer(CONTINUE_SYNC_TIMER, Duration::from_millis(2500)).expect("Error registering sync timer");
 			io.register_timer(TX_TIMER, Duration::from_millis(1300)).expect("Error registering transactions timer");
+			io.register_timer(DELAYED_PROCESSING_TIMER, Duration::from_millis(2000)).expect("Error registering delayed processing timer");
 
 			io.register_timer(PRIORITY_TIMER, PRIORITY_TIMER_INTERVAL).expect("Error registering peers timer");
 		}
@@ -539,6 +541,7 @@ impl NetworkProtocolHandler for SyncProtocolHandler {
 			CONTINUE_SYNC_TIMER => self.sync.write().continue_sync(&mut io),
 			TX_TIMER => self.sync.write().propagate_new_transactions(&mut io),
 			PRIORITY_TIMER => self.sync.process_priority_queue(&mut io),
+			DELAYED_PROCESSING_TIMER => self.sync.process_delayed_requests(&mut io),
 			_ => warn!("Unknown timer {} triggered.", timer),
 		}
 	}

--- a/ethcore/sync/src/block_sync.rs
+++ b/ethcore/sync/src/block_sync.rs
@@ -232,7 +232,7 @@ impl BlockDownloader {
 	}
 
 	/// Reset sync to the specified block
-	pub fn reset_to_block(&mut self, start_hash: &H256, start_number: BlockNumber) {
+	fn reset_to_block(&mut self, start_hash: &H256, start_number: BlockNumber) {
 		self.reset();
 		self.last_imported_block = start_number;
 		self.last_imported_hash = start_hash.clone();

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -163,7 +163,7 @@ impl SyncHandler {
 		// Use td and hash, that peer must have for now
 		let parent_td = difficulty.checked_sub(*block.header.difficulty());
 		if let Some(ref mut peer) = sync.peers.get_mut(&peer_id) {
-			if peer.difficulty.map_or(true, |pd| parent_td.map_or(true, |td| td > pd)) {
+			if peer.difficulty.map_or(true, |pd| parent_td.map_or(false, |td| td > pd)) {
 				peer.difficulty = parent_td;
 			}
 		}

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -31,7 +31,7 @@ use crate::{
 				SnapshotDataPacket, SnapshotManifestPacket, StatusPacket,
 			}
 		},
-		BlockSet, ChainSync, ForkConfirmation, PacketDecodeError, PeerAsking, PeerInfo, SyncRequester,
+		BlockSet, ChainSync, ForkConfirmation, PacketProcessError, PeerAsking, PeerInfo, SyncRequester,
 		SyncState, ETH_PROTOCOL_VERSION_63, ETH_PROTOCOL_VERSION_64, MAX_NEW_BLOCK_AGE, MAX_NEW_HASHES,
 		PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_3, PAR_PROTOCOL_VERSION_4,
 	}
@@ -675,7 +675,7 @@ impl SyncHandler {
 	}
 
 	/// Called when peer sends us new transactions
-	pub fn on_peer_transactions(sync: &ChainSync, io: &mut dyn SyncIo, peer_id: PeerId, tx_rlp: Rlp) -> Result<(), PacketDecodeError> {
+	pub fn on_peer_transactions(sync: &ChainSync, io: &mut dyn SyncIo, peer_id: PeerId, tx_rlp: Rlp) -> Result<(), PacketProcessError> {
 		// Accept transactions only when fully synced
 		if !io.is_chain_queue_empty() || (sync.state != SyncState::Idle && sync.state != SyncState::NewBlocks) {
 			trace!(target: "sync", "{} Ignoring transactions while syncing", peer_id);

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -114,6 +114,7 @@ impl SyncHandler {
 			debug!(target: "sync", "Disconnected {}", peer_id);
 			sync.clear_peer_download(peer_id);
 			sync.peers.remove(&peer_id);
+			sync.delayed_requests.retain(|(request_peer_id, _, _)| *request_peer_id != peer_id);
 			sync.active_peers.remove(&peer_id);
 
 			if sync.state == SyncState::SnapshotManifest {

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -160,10 +160,10 @@ impl SyncHandler {
 		let difficulty: U256 = r.val_at(1)?;
 		// Most probably the sent block is being imported by peer right now
 		// Use td and hash, that peer must have for now
-		let parent_td = difficulty - block.header.difficulty();
+		let parent_td = difficulty.checked_sub(*block.header.difficulty());
 		if let Some(ref mut peer) = sync.peers.get_mut(&peer_id) {
-			if peer.difficulty.map_or(true, |pd| parent_td > pd) {
-				peer.difficulty = Some(parent_td);
+			if peer.difficulty.map_or(true, |pd| parent_td.map_or(true, |td| td > pd)) {
+				peer.difficulty = parent_td;
 			}
 		}
 		let mut unknown = false;

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -490,8 +490,8 @@ impl ChainSyncApi {
 		let requests = self.sync.write().retrieve_delayed_requests();
 		if !requests.is_empty() {
 			debug!(target: "sync", "Processing {} delayed requests", requests.len());
-			for request in requests {
-				SyncSupplier::postponed_dispatch_packet(&self.sync, io, request.0, request.1, &request.2);
+			for (peer_id, packet_id, packet_data) in requests {
+				SyncSupplier::dispatch_delayed_request(&self.sync, io, peer_id, packet_id, &packet_data);
 			}
 		}
 	}

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -487,10 +487,7 @@ impl ChainSyncApi {
 
 	/// Process the queue with requests, that were delayed with response.
 	pub fn process_delayed_requests(&self, io: &mut dyn SyncIo) {
-		let requests;
-		{
-			requests = self.sync.write().retrieve_delayed_requests();
-		}
+		let requests = self.sync.write().retrieve_delayed_requests();
 		if !requests.is_empty() {
 			debug!(target: "sync", "Processing {} delayed requests", requests.len());
 			for request in requests {
@@ -1307,7 +1304,7 @@ impl ChainSync {
 		packet.append(&chain.total_difficulty);
 		packet.append(&chain.best_block_hash);
 		packet.append(&chain.genesis_hash);
-		if eth_protocol_version >= ETH_PROTOCOL_VERSION_64.0 { 
+		if eth_protocol_version >= ETH_PROTOCOL_VERSION_64.0 {
 			packet.append(&self.fork_filter.current(io.chain()));
 		}
 		if warp_protocol {

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -113,6 +113,7 @@ use crate::{
 
 use bytes::Bytes;
 use client_traits::BlockChainClient;
+use derive_more::Display;
 use ethereum_types::{H256, U256};
 use fastmap::{H256FastMap, H256FastSet};
 use futures::sync::mpsc as futures_mpsc;
@@ -147,7 +148,23 @@ pub(crate) use self::supplier::SyncSupplier;
 
 malloc_size_of_is_0!(PeerInfo);
 
-pub type PacketDecodeError = DecoderError;
+/// Possible errors during packet's processing
+#[derive(Debug, Display)]
+pub enum PacketProcessError {
+	/// Error of RLP decoder
+	#[display(fmt = "Decoder Error: {}", _0)]
+	Decoder(DecoderError),
+	/// Underlying client is busy and cannot process the packet
+	/// The packet should be postponed for later response
+	#[display(fmt = "Underlying client is busy")]
+	ClientBusy,
+}
+
+impl From<DecoderError> for PacketProcessError {
+	fn from(err: DecoderError) -> Self {
+		PacketProcessError::Decoder(err).into()
+	}
+}
 
 /// Version 64 of the Ethereum protocol and number of packet IDs reserved by the protocol (packet count).
 pub const ETH_PROTOCOL_VERSION_64: (u8, u8) = (64, 0x11);
@@ -411,7 +428,7 @@ pub mod random {
 	}
 }
 
-pub type RlpResponseResult = Result<Option<(PacketId, RlpStream)>, PacketDecodeError>;
+pub type RlpResponseResult = Result<Option<(PacketId, RlpStream)>, PacketProcessError>;
 pub type Peers = HashMap<PeerId, PeerInfo>;
 
 /// Thread-safe wrapper for `ChainSync`.
@@ -466,6 +483,20 @@ impl ChainSyncApi {
 	/// Dispatch incoming requests and responses
 	pub fn dispatch_packet(&self, io: &mut dyn SyncIo, peer: PeerId, packet_id: u8, data: &[u8]) {
 		SyncSupplier::dispatch_packet(&self.sync, io, peer, packet_id, data)
+	}
+
+	/// Process the queue with requests, that were delayed with response.
+	pub fn process_delayed_requests(&self, io: &mut dyn SyncIo) {
+		let requests;
+		{
+			requests = self.sync.write().retrieve_delayed_requests();
+		}
+		if !requests.is_empty() {
+			debug!(target: "sync", "Processing {} delayed requests", requests.len());
+			for request in requests {
+				SyncSupplier::dispatch_packet(&self.sync, io, request.0, request.1, &request.2)
+			}
+		}
 	}
 
 	/// Process a priority propagation queue.
@@ -672,6 +703,8 @@ pub struct ChainSync {
 	/// Connected peers pending Status message.
 	/// Value is request timestamp.
 	handshaking_peers: HashMap<PeerId, Instant>,
+	/// Requests, that can not be processed at the moment
+	delayed_requests: HashSet<(PeerId, u8, Vec<u8>)>,
 	/// Sync start timestamp. Measured when first peer is connected
 	sync_start_time: Option<Instant>,
 	/// Transactions propagation statistics
@@ -707,6 +740,7 @@ impl ChainSync {
 			peers: HashMap::new(),
 			handshaking_peers: HashMap::new(),
 			active_peers: HashSet::new(),
+			delayed_requests: HashSet::new(),
 			new_blocks: BlockDownloader::new(BlockSet::NewBlocks, &chain_info.best_block_hash, chain_info.best_block_number),
 			old_blocks: None,
 			last_sent_block_number: 0,
@@ -819,6 +853,20 @@ impl ChainSync {
 		// Reactivate peers only if some progress has been made
 		// since the last sync round of if starting fresh.
 		self.active_peers = self.peers.keys().cloned().collect();
+
+		self.delayed_requests = HashSet::new();
+	}
+
+	/// Add a request for later processing
+	pub fn add_delayed_request(&mut self, peer: PeerId, packet_id: u8, data: &[u8]) {
+		if self.delayed_requests.insert((peer, packet_id, data.to_vec())) {
+			debug!(target: "sync", "Delayed request with packet id {} from peer {} added", packet_id, peer);
+		}
+	}
+
+	/// Drain and return all delayed requests
+	pub fn retrieve_delayed_requests(&mut self) -> Vec<(PeerId, u8, Vec<u8>)> {
+		self.delayed_requests.drain().collect()
 	}
 
 	/// Restart sync

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -153,9 +153,9 @@ impl SyncSupplier {
 		}
 	}
 
-	/// Dispatch delayed requests
+	/// Dispatch delayed request
 	/// The main difference with dispatch packet is the direct send of the responses to the peer
-	pub fn postponed_dispatch_packet(sync: &RwLock<ChainSync>, io: &mut dyn SyncIo, peer: PeerId, packet_id: u8, data: &[u8]) {
+	pub fn dispatch_delayed_request(sync: &RwLock<ChainSync>, io: &mut dyn SyncIo, peer: PeerId, packet_id: u8, data: &[u8]) {
 		let rlp = Rlp::new(data);
 
 		if let Some(id) = SyncPacket::from_u8(packet_id) {

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -153,6 +153,9 @@ impl SyncSupplier {
 
 	/// Respond to GetBlockHeaders request
 	fn return_block_headers(io: &dyn SyncIo, r: &Rlp, peer_id: PeerId) -> RlpResponseResult {
+		// Wait if blocks with forks are being processed
+		// This call will be waiting on client's import mutex, if there are blocks with possible fork in queue
+		io.chain().process_fork();
 		let payload_soft_limit = io.payload_soft_limit();
 		// Packet layout:
 		// [ block: { P , B_32 }, maxHeaders: P, skip: P, reverse: P in { 0 , 1 } ]

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -431,15 +431,11 @@ impl SyncSupplier {
 			FError : FnOnce(network::Error) -> String
 	{
 		let response = rlp_func(io, rlp, peer);
-		match response {
-			Err(e) => Err(e),
-			Ok(Some((packet_id, rlp_stream))) => {
-				io.respond(packet_id.id(), rlp_stream.out()).unwrap_or_else(
-					|e| debug!(target: "sync", "{:?}", error_func(e)));
-				Ok(())
-			}
-			_ => Ok(())
+		if let Some((packet_id, rlp_stream)) = response? {
+			io.respond(packet_id.id(), rlp_stream.out()).unwrap_or_else(
+				|e| debug!(target: "sync", "{:?}", error_func(e)));
 		}
+		Ok(())
 	}
 
 	fn send_rlp<FRlp, FError>(io: &mut dyn SyncIo, rlp: &Rlp, peer: PeerId, rlp_func: FRlp, error_func: FError) -> Result<(), PacketProcessError>

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -43,7 +43,6 @@ pub mod kind;
 
 const MIN_MEM_LIMIT: usize = 16384;
 const MIN_QUEUE_LIMIT: usize = 512;
-const MAX_QUEUE_WITH_FORK: usize = 8;
 
 /// Type alias for block queue convenience.
 pub type BlockQueue<C> = VerificationQueue<self::kind::Blocks, C>;
@@ -144,6 +143,7 @@ pub struct VerificationQueue<K: Kind, C: 'static> {
 	ready_signal: Arc<QueueSignal<C>>,
 	empty: Arc<Condvar>,
 	processing: RwLock<HashMap<H256, (U256, H256)>>, // hash to difficulty and parent hash
+	processing_parents: RwLock<HashMap<H256, usize>>, // parent hashes of all items in processing with amount of children in queue
 	ticks_since_adjustment: AtomicUsize,
 	max_queue_size: usize,
 	max_mem_use: usize,
@@ -279,6 +279,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 			verification,
 			deleting,
 			processing: RwLock::new(HashMap::new()),
+			processing_parents: RwLock::new(HashMap::new()),
 			empty,
 			ticks_since_adjustment: AtomicUsize::new(0),
 			max_queue_size: cmp::max(config.max_queue_size, MIN_QUEUE_LIMIT),
@@ -447,6 +448,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 		*self.total_difficulty.write() = 0.into();
 
 		self.processing.write().clear();
+		self.processing_parents.write().clear();
 	}
 
 	/// Wait for unverified queue to be empty
@@ -496,11 +498,18 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 					return Err((Error::Import(ImportError::AlreadyQueued), None));
 				}
 				self.verification.sizes.unverified.fetch_add(item.malloc_size_of(), AtomicOrdering::SeqCst);
-				self.processing.write().insert(hash, (item.difficulty(), item.parent_hash()));
+				let parent_hash = item.parent_hash();
+				self.processing.write().insert(hash, (item.difficulty(), parent_hash));
 				{
 					let mut td = self.total_difficulty.write();
 					*td = *td + item.difficulty();
 				}
+				let mut parent_hashes = self.processing_parents.write();
+				let mut children_count = 0;
+				if let Some(count) = parent_hashes.get(&parent_hash) {
+					children_count = *count;
+				}
+				parent_hashes.insert(parent_hash, children_count + 1);
 				self.verification.unverified.lock().push_back(item);
 				self.more_to_verify.notify_all();
 				Ok(hash)
@@ -528,6 +537,17 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 		}
 	}
 
+	fn decrease_processing_children_count(&self, parent_hash: &H256) {
+		if let Some(children_count) = self.processing_parents.read().get(parent_hash) {
+			let mut parent_hashes = self.processing_parents.write();
+			if *children_count == 1 {
+				parent_hashes.remove(parent_hash);
+			} else {
+				parent_hashes.insert(*parent_hash, *children_count - 1);
+			}
+		}
+	}
+
 	/// Mark given item and all its children as bad. pauses verification
 	/// until complete.
 	pub fn mark_as_bad(&self, hashes: &[H256]) {
@@ -544,6 +564,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 			if let Some(item) = processing.remove(hash) {
 				let mut td = self.total_difficulty.write();
 				*td = *td - item.0;
+				self.decrease_processing_children_count(&item.1);
 			}
 		}
 
@@ -556,6 +577,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 				if let Some(item) = processing.remove(&output.hash()) {
 					let mut td = self.total_difficulty.write();
 					*td = *td - item.0;
+					self.decrease_processing_children_count(&item.1);
 				}
 			} else {
 				new_verified.push_back(output);
@@ -577,6 +599,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 			if let Some(item) = processing.remove(hash) {
 				let mut td = self.total_difficulty.write();
 				*td = *td - item.0;
+				self.decrease_processing_children_count(&item.1);
 			}
 		}
 		processing.is_empty()
@@ -610,13 +633,9 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 	/// Returns true, if in processing queue there is no descendant of the current best block
 	/// May return false negative for longer queues
 	pub fn is_processing_fork(&self, best_block_hash: &H256, chain: &BlockChain) -> bool {
-		let processing = self.processing.read();
-		if processing.is_empty() || processing.len() > MAX_QUEUE_WITH_FORK {
-			// Assume, that long enough processing queue doesn't have fork blocks
-			return false;
-		}
-		for item in processing.values() {
-			if chain.tree_route(item.1, *best_block_hash).is_some() {
+		let processing_parents = self.processing_parents.read();
+		for parent_hash in processing_parents.keys() {
+			if chain.tree_route(*parent_hash, *best_block_hash).is_some() {
 				return false;
 			}
 		}

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -616,7 +616,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 			return false;
 		}
 		for (_, item_parent_hash) in processing.values() {
-			if chain.tree_route(*best_block_hash, item_parent_hash).map_or(true, |route| route.ancestor != *best_block_hash) {
+			if chain.tree_route(*best_block_hash, *item_parent_hash).map_or(true, |route| route.ancestor != *best_block_hash) {
 				return true;
 			}
 		}

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -145,7 +145,7 @@ pub struct VerificationQueue<K: Kind, C: 'static> {
 	deleting: Arc<AtomicBool>,
 	ready_signal: Arc<QueueSignal<C>>,
 	empty: Arc<Condvar>,
-	processing: RwLock<HashMap<H256, (U256, H256)>>, // hash to difficulty and parent hash
+	processing: RwLock<HashMap<H256, (U256, H256)>>, // item's hash to difficulty and parent item hash
 	ticks_since_adjustment: AtomicUsize,
 	max_queue_size: usize,
 	max_mem_use: usize,
@@ -620,7 +620,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 				return true;
 			}
 		}
-		return false;
+		false
 	}
 
 	/// Get queue status.

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -607,6 +607,11 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 			&& v.verified.load_len() == 0
 	}
 
+	/// Returns true if there are items being processed currently in the queue.
+	pub fn is_processing(&self) -> bool {
+		!self.processing.read().is_empty()
+	}
+
 	/// Returns true, if in processing queue there is no descendant of the current best block
 	/// May return false negative for longer queues
 	pub fn is_processing_fork(&self, best_block_hash: &H256, chain: &BlockChain) -> bool {

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -607,11 +607,6 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 			&& v.verified.load_len() == 0
 	}
 
-	/// Returns true if there are items being processed currently in the queue.
-	pub fn is_processing(&self) -> bool {
-		!self.processing.read().is_empty()
-	}
-
 	/// Returns true, if in processing queue there is no descendant of the current best block
 	/// May return false negative for longer queues
 	pub fn is_processing_fork(&self, best_block_hash: &H256, chain: &BlockChain) -> bool {

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -605,20 +605,19 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 			&& v.verified.load_len() == 0
 	}
 
-	/// Returns true, if in processing queue there is no descendant of the current best block
+	/// Returns true, if in processing queue there are descendants of the current best block
 	pub fn is_processing_fork(&self, best_block_hash: &H256) -> bool {
 		let processing = self.processing.read();
 		if processing.is_empty() || processing.len() > MAX_QUEUE_WITH_FORK {
 			// Assume, that long enough processing queue doesn't have fork blocks
 			return false;
 		}
-
 		for item in processing.values() {
-			if item.1 == *best_block_hash {
-				return false;
+			if chain.tree_route(*best_block_hash, item.1).map_or(true, |route| route.ancestor != *best_block_hash) {
+				return true;
 			}
 		}
-		return true;
+		return false;
 	}
 
 	/// Get queue status.

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -491,11 +491,10 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 
 		match K::create(input, &*self.engine, self.verification.check_seal) {
 			Ok(item) => {
-				if self.processing.write().insert(hash, item.difficulty()).is_some() {
+				if self.processing.write().insert(hash, (item.difficulty(), item.parent_hash())).is_some() {
 					return Err((Error::Import(ImportError::AlreadyQueued), None));
 				}
 				self.verification.sizes.unverified.fetch_add(item.malloc_size_of(), AtomicOrdering::SeqCst);
-				self.processing.write().insert(hash, (item.difficulty(), item.parent_hash()));
 				{
 					let mut td = self.total_difficulty.write();
 					*td = *td + item.difficulty();

--- a/ethcore/verification/src/queue/mod.rs
+++ b/ethcore/verification/src/queue/mod.rs
@@ -28,6 +28,7 @@ use common_types::{
 	errors::{BlockError, EthcoreError as Error, ImportError},
 	verification::VerificationQueueInfo as QueueInfo,
 };
+use blockchain::BlockChain;
 use ethcore_io::*;
 use ethereum_types::{H256, U256};
 use engine::Engine;
@@ -606,7 +607,7 @@ impl<K: Kind, C> VerificationQueue<K, C> {
 	}
 
 	/// Returns true, if in processing queue there are descendants of the current best block
-	pub fn is_processing_fork(&self, best_block_hash: &H256) -> bool {
+	pub fn is_processing_fork(&self, best_block_hash: &H256, chain: &BlockChain) -> bool {
 		let processing = self.processing.read();
 		if processing.is_empty() || processing.len() > MAX_QUEUE_WITH_FORK {
 			// Assume, that long enough processing queue doesn't have fork blocks


### PR DESCRIPTION
**Purpose**
This PR aims to fix issues in the following scenario during block sync:

1) There are two connected nodes A and F
2) Sync is going up to block N for both nodes

3) Node A receives notification from F about the new block with unknown parent. This notification can be caused by multiple reasons:
-- Fork happened and new subchain started from N block, in this case F sends notification about N'+1 block (and parent in N')
-- There were several "light" (light in terms of difficulty and import speed) blocks N+1, N+2, .. and one "heavy" block N+x after them in blocks import queue for F, in this case F may send notification only about "heavy" one N+x
-- Notifications about previous blocks were simple lost somehow
-- Some combination of all three
NOTE: Current block sync was designed with the assumption, that the node sends NewBlock message, only when the import of this block is completed. This assumption was changed by @tomusdrw in his #9954, now the node sends this notification before importing blocks.

4) Node A starts retraction in order to find the beginning of possible fork, requesting headers for blocks N, N-1, N-2, N-3 etc from F
5) Meanwhile node F has not yet completed the import of the block, the notification about was sent to A, so it responds with old blocks, that do not consider new blocks, that are being imported
6) Node A quickly runs into N - 128 block (128 is the limit for number of requested headers)
7) Node F finishes new blocks import
8) Unfortunately retraction on node A went too far already and A requested 128 headers beginning from N - M block, where M > 128. As a result, F returns old 128 headers without new N' and N'+ 1
Also A doesn't receive the notifications about the new blocks from F (that could break the circle), because A constantly requests F, considers node F as "busy" and doesn't start new sync with it correspondingly. 
9) Node A continues retraction to 0 and sync stops.

**Addressed issues**
This PR fixes several problems in handling of such scenario 
1) Node F should not reply to GetBlockHeaders request until fork import is finished, because such answer won't be legit already. The reply is postponed in such case.
2) Node A should not immediately request the new block, because most probably its import is not finished yet. Instead, node A uses the parent block of came new block as a further reference point. Please note, that the same logic and assumption exists in geth: https://github.com/ethereum/go-ethereum/blob/master/eth/handler.go#L718
3) There was an infinity loop in retraction procedure, when it came to block number 0 (it's not a surprise, that this issue was not easily discovered before, because it only matters for archive nodes). Because of this loop the retraction was stucking around 0 block (and sync stopped in result). 

**Achieved results**
So with all fixes in place the possibility of the described scenario is significantly decreased, the node A doesn't request blocks prematurely. Almost. Unfortunately, we observed situations during the testing, when retraction on node A still started and went behind the point of no return (block N - 128). This happened in pretty weird use cases of several forks in the row, when current block sync algorithm just simply could not handle such situation. In these cases I considered described retractions as legit, in spite of its predetermined result and required time (several minutes). I just fixed it in order to be properly restarted at the end, when no fork was found (item 3 in the list of addressed issues). As a result, the sync was paused for several minutes, but automatically recovered by itself and continued.

**Comments**
This problem is reproduced on configuration from #10724 when A and F run locally on one machine and A is only connected to F (F connected to the whole mainnet). As a result, network latency between A and F is low and A can quickly descend down to N - M block to the stuck condition. Also node A doesn't have any other sources of blocks but node F. For regular configurations stuck is less likely but it still causes overhead by sequences of GetBlock requests emitted by nodes, trying to find the common parent in such situation.

PS Huge shoutout to @iFA88 for the invaluable help in reproducing the scenarios and debugging 