### PR TITLE
Add Docker build and push to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,3 +100,4 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: scripts/docker/alpine/Dockerfile
           buildargs: VCS_REF,BUILD_DATE
+          tag_names: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,12 @@ jobs:
       - name:                   Deploy to docker hub
         if:                     matrix.platform == 'ubuntu-16.04'
         uses: elgohr/Publish-Docker-Github-Action@master
+        env:
+          VCS_REF: $GITHUB_SHA
+          BUILD_DATE: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
         with:
           name: openethereum/openethereum
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: scripts/docker/alpine/Dockerfile
+          buildargs: VCS_REF,BUILD_DATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,11 @@ jobs:
       - name:                   Prepare build directory for cache
         shell: bash
         run:                    bash scripts/actions/clean-target.sh
+      - name:                   Deploy to docker hub
+        if:                     matrix.platform == 'ubuntu-16.04'
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: openethereum/openethereum
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: scripts/docker/alpine/Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,16 +88,3 @@ jobs:
       - name:                   Prepare build directory for cache
         shell: bash
         run:                    bash scripts/actions/clean-target.sh
-      - name:                   Deploy to docker hub
-        if:                     matrix.platform == 'ubuntu-16.04'
-        uses: elgohr/Publish-Docker-Github-Action@master
-        env:
-          VCS_REF: $GITHUB_SHA
-          BUILD_DATE: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
-        with:
-          name: openethereum/openethereum
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: scripts/docker/alpine/Dockerfile
-          buildargs: VCS_REF,BUILD_DATE
-          tag_names: true

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on:                    ubuntu-latest
     steps:
       - name:                   Deploy to docker hub
-        if:                     matrix.platform == 'ubuntu-16.04'
         uses: elgohr/Publish-Docker-Github-Action@master
         env:
           VCS_REF: $GITHUB_SHA

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,0 +1,27 @@
+name:                           Docker Image Release
+
+on:
+  push:
+    branches:
+      - stable
+    tags:
+      - v2*
+
+jobs:
+  deploy-docker:
+    name:                       Build Release
+    runs-on:                    ubuntu-latest
+    steps:
+      - name:                   Deploy to docker hub
+        if:                     matrix.platform == 'ubuntu-16.04'
+        uses: elgohr/Publish-Docker-Github-Action@master
+        env:
+          VCS_REF: $GITHUB_SHA
+          BUILD_DATE: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+        with:
+          name: openethereum/openethereum
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: scripts/docker/alpine/Dockerfile
+          buildargs: VCS_REF,BUILD_DATE
+          tag_names: true

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -22,9 +22,6 @@ jobs:
           override:             true
       - name:                   Deploy to docker hub
         uses: elgohr/Publish-Docker-Github-Action@master
-        env:
-          VCS_REF: $GITHUB_SHA
-          BUILD_DATE: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
         with:
           name: openethereum/openethereum
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -12,6 +12,16 @@ jobs:
     name:                       Build Release
     runs-on:                    ubuntu-latest
     steps:
+      - name:                   Checkout sources
+        uses:                   actions/checkout@v2
+        with:
+          fetch-depth:          50
+      - name:                   Install toolchain
+        uses:                   actions-rs/toolchain@v1
+        with:
+          toolchain:            stable
+          profile:              minimal
+          override:             true
       - name:                   Deploy to docker hub
         uses: elgohr/Publish-Docker-Github-Action@master
         env:

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -30,5 +30,4 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: scripts/docker/alpine/Dockerfile
-          buildargs: VCS_REF,BUILD_DATE
           tag_names: true

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -13,9 +13,7 @@ jobs:
     runs-on:                    ubuntu-latest
     steps:
       - name:                   Checkout sources
-        uses:                   actions/checkout@v2
-        with:
-          fetch-depth:          50
+        uses:                   actions/checkout@master
       - name:                   Install toolchain
         uses:                   actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
It uses community action: https://github.com/marketplace/actions/publish-docker
It deploys based on tag name and also pushes master as latest.

A few considerations:
1. Build of docker image is done in the same process than build for ubuntu, this is not ideal as is a sequential process. Maybe we could add it in the matrix for the release stage.
2. Is not using sccache, it would need to have a volume shared, for simplicity is not done right now.
3. Is not using any docker cache. 