### PR TITLE
Use serde_json to export hardcoded sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4820,6 +4820,8 @@ dependencies = [
  "parity-bytes",
  "pod",
  "rlp",
+ "serde",
+ "serde_json",
  "tempfile",
  "trace",
  "trie-vm-factories",

--- a/ethcore/spec/Cargo.toml
+++ b/ethcore/spec/Cargo.toml
@@ -32,6 +32,8 @@ maplit = "1"
 null-engine = { path = "../engines/null-engine" }
 pod = { path = "../pod" }
 rlp = "0.4.2"
+serde = "1.0"
+serde_json = "1.0"
 trace = { path = "../trace" }
 trie-vm-factories = { path = "../trie-vm-factories" }
 vm = { path = "../vm" }


### PR DESCRIPTION
The exported hardcoded sync was previously generating invalid JSON, with
the CHT list ending in a trailing comma. In order to remedy this, this
commit uses serde_json to serialize the SpecHardcodedSync struct
into valid JSON.

Fixes #11415