### PR TITLE
Fix UNKNOWN values on docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,7 @@ target
 # idea ide
 .idea
 
-# git stuff
-.git
+# git folder is not ignored so vergen library can get the commit hash and date for the build
+#.git
 
 ethcore/res/ethereum/tests


### PR DESCRIPTION
In the previous build for docker images, it had the .git folder ignored. It makes sense to ignore it, it's a big folder and usually it doesn't get used.

The problem is that it's used in the compilation by this library https://docs.rs/vergen/3.1.0/vergen/
And is the reason why with the current build, there are two unknown values:

2020-04-02 15:52:59 UTC Starting OpenEthereum/v3.0.0-alpha.1-nightly-UNKNOWN-UNKNOWN/x86_64-alpine-linux-musl/rustc1.42.0

With this PR, this issue gets solved.

Thanks to the way the alpine docker file has been written, the final size of the image is not affected by this PR as the docker image is built in a multistage process and only the binaries are included in the final image.