### PR TITLE
evm: implement simple subroutine

### DIFF
--- a/ethcore/evm/src/instructions.rs
+++ b/ethcore/evm/src/instructions.rs
@@ -321,6 +321,13 @@ enum_with_from_u8! {
 		#[doc = "Makes a log entry, 4 topics."]
 		LOG4 = 0xa4,
 
+		#[doc = "Jump to a subrountine."]
+		JUMPSUB = 0xb3,
+		#[doc = "Begin a subrountine."]
+		BEGINSUB = 0xb5,
+		#[doc = "Return from a subrountine."]
+		RETURNSUB = 0xb7,
+
 		#[doc = "create a new account with associated code"]
 		CREATE = 0xf0,
 		#[doc = "message-call into an account"]
@@ -595,6 +602,9 @@ lazy_static! {
 		arr[SUICIDE as usize] = Some(InstructionInfo::new("SUICIDE", 1, 0, GasPriceTier::Special));
 		arr[CREATE2 as usize] = Some(InstructionInfo::new("CREATE2", 4, 1, GasPriceTier::Special));
 		arr[REVERT as usize] = Some(InstructionInfo::new("REVERT", 2, 0, GasPriceTier::Zero));
+		arr[BEGINSUB as usize] = Some(InstructionInfo::new("BEGINSUB", 0, 0, GasPriceTier::Base));
+		arr[JUMPSUB as usize] = Some(InstructionInfo::new("JUMPSUB", 1, 0, GasPriceTier::Low));
+		arr[RETURNSUB as usize] = Some(InstructionInfo::new("RETURNSUB", 0, 0, GasPriceTier::VeryLow));
 		arr
 	};
 }

--- a/ethcore/vm/src/error.rs
+++ b/ethcore/vm/src/error.rs
@@ -48,6 +48,12 @@ pub enum Error {
 		/// Position the code tried to jump to.
 		destination: usize
 	},
+	/// `BadSubDestination` is returned when execution tried to move
+	/// to position that wasn't marked with BEGINSUB instruction
+	BadSubDestination {
+		/// Position the code tried to jump to.
+		destination: usize
+	},
 	/// `BadInstructions` is returned when given instruction is not supported
 	BadInstruction {
 		/// Unrecognized opcode
@@ -71,6 +77,12 @@ pub enum Error {
 		/// What was the stack limit
 		limit: usize
 	},
+	/// Return stack overflowed.
+	OutOfReturnStack,
+	/// Invalid subroutine target.
+	InvalidSub,
+	/// Return stack underflowed.
+	ReturnStackUnderflow,
 	/// Built-in contract failed on given input
 	BuiltIn(&'static str),
 	/// When execution tries to modify the state in static context
@@ -103,9 +115,13 @@ impl fmt::Display for Error {
 		match *self {
 			OutOfGas => write!(f, "Out of gas"),
 			BadJumpDestination { destination } => write!(f, "Bad jump destination {:x}", destination),
+			BadSubDestination { destination } => write!(f, "Bad sub destination {:x}", destination),
 			BadInstruction { instruction } => write!(f, "Bad instruction {:x}",  instruction),
 			StackUnderflow { instruction, wanted, on_stack } => write!(f, "Stack underflow {} {}/{}", instruction, wanted, on_stack),
 			OutOfStack { instruction, wanted, limit } => write!(f, "Out of stack {} {}/{}", instruction, wanted, limit),
+			OutOfReturnStack => write!(f, "Out of return stack"),
+			InvalidSub => write!(f, "Invalid subrountine target"),
+			ReturnStackUnderflow => write!(f, "Return stack underflow"),
 			BuiltIn(name) => write!(f, "Built-in failed: {}", name),
 			Internal(ref msg) => write!(f, "Internal error: {}", msg),
 			MutableCallInStaticContext => write!(f, "Mutable call in static context"),


### PR DESCRIPTION
This is a draft of implementation of EIP-2315 (https://eips.ethereum.org/EIPS/eip-2315) simple subroutine. Code locations can be marked as subroutines, and opcodes are introduced to jump to it and return from it (via a newly-introduced "return stack").

rel https://github.com/openethereum/openethereum/issues/11562