### PR TITLE
Deduplicating crate dependencies (part 2 of n, `slab`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "slab 0.2.0",
+ "slab 0.4.2",
  "tempfile",
  "tiny-keccak 1.5.0",
 ]
@@ -4590,12 +4590,6 @@ name = "siphasher"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e88f89a550c01e4cd809f3df4f52dc9e939f3273a2017eabd5c6d12fd98bb23"
-
-[[package]]
-name = "slab"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbdd334bd28d328dad1c41b0ea662517883d8880d8533895ef96c8003dec9c4"
 
 [[package]]
 name = "slab"

--- a/util/io/Cargo.toml
+++ b/util/io/Cargo.toml
@@ -13,7 +13,7 @@ mio = { version = "0.6.19", optional = true }
 crossbeam-deque = "0.7.3"
 parking_lot = "0.10.0"
 log = "0.4"
-slab = "0.4"
+slab = "0.4.2"
 num_cpus = "1.8"
 timer = "0.2"
 time = "0.1"

--- a/util/network-devp2p/Cargo.toml
+++ b/util/network-devp2p/Cargo.toml
@@ -33,7 +33,7 @@ rlp = "0.4.0"
 secp256k1 = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-slab = "0.2"
+slab = "0.4.2"
 tiny-keccak = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
The change includes only `slab` module.

#11468