### PR TITLE
deps: switch to upstream ctrlc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,12 +862,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "1.1.1"
-source = "git+https://github.com/paritytech/rust-ctrlc.git#b523017108bb2d571a7a69bd97bc406e63bc7a9d"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
 dependencies = [
- "kernel32-sys",
- "libc",
- "winapi 0.2.8",
+ "nix",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2995,6 +2995,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
 ]
 
 [[package]]
@@ -5604,6 +5617,12 @@ dependencies = [
  "patricia-trie-ethereum",
  "rlp",
 ]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2"
 cli-signer= { path = "cli-signer" }
 client-traits = { path = "ethcore/client-traits" }
 common-types = { path = "ethcore/types" }
-ctrlc = { git = "https://github.com/paritytech/rust-ctrlc.git" }
+ctrlc = { version = "3.1.4", features = ["termination"] }
 dir = { path = "util/dir" }
 docopt = "1.0"
 engine = { path = "ethcore/engine" }

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -41,7 +41,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{process, env};
 
 use ansi_term::Colour;
-use ctrlc::CtrlC;
 use dir::default_hypervisor_path;
 use fdlimit::raise_fd_limit;
 use ethcore_logger::setup_log;
@@ -299,7 +298,7 @@ fn main_direct(force_can_restart: bool) -> i32 {
 					}
 				});
 
-				CtrlC::set_handler({
+				ctrlc::set_handler({
 					let e = exit.clone();
 					let exiting = exiting.clone();
 					move || {
@@ -313,7 +312,7 @@ fn main_direct(force_can_restart: bool) -> i32 {
 							e.1.notify_all();
 						}
 					}
-				});
+				}).expect("Error setting Ctrl-C handler");
 
 				// so the client has started successfully
 				// if this is a daemon, detach from the parent process


### PR DESCRIPTION
Looking at winapi 0.2.8 reverse dependencies I've noticed our fork of `ctrlc` crate which we haven't updated in a while. It seems it added support for `SIGTERM` flag (which upstream already supports via a feature flag `termination`) and `SIGKILL` (I don't think it ever worked because it's not possible to handle `SIGKILL` at least on Linux): 
https://github.com/Detegr/rust-ctrlc/compare/master...paritytech:master.

This PR switches to upstream ctrlc crate and we should probably archive/remove [paritytech's fork](https://github.com/paritytech/rust-ctrlc).