### PR TITLE
remove eip-2200-advance transition

### DIFF
--- a/ethcore/spec/src/spec.rs
+++ b/ethcore/spec/src/spec.rs
@@ -407,7 +407,6 @@ impl Spec {
 			params.eip1344_transition,
 			params.eip1884_transition,
 			params.eip2028_transition,
-			params.eip2200_advance_transition,
 			params.dust_protection_transition,
 			params.wasm_activation_transition,
 			params.kip4_transition,

--- a/ethcore/types/src/engines/params.rs
+++ b/ethcore/types/src/engines/params.rs
@@ -102,8 +102,6 @@ pub struct CommonParams {
 	pub eip2028_transition: BlockNumber,
 	/// Number of first block where EIP-2046/1352 rules begin.
 	pub eip2046_transition: BlockNumber,
-	/// Number of first block where EIP-2200 advance transition begin.
-	pub eip2200_advance_transition: BlockNumber,
 	/// Number of first block where dust cleanup rules (EIP-168 and EIP169) begin.
 	pub dust_protection_transition: BlockNumber,
 	/// Nonce cap increase per block. Nonce cap is only checked if dust protection is enabled.
@@ -188,10 +186,6 @@ impl CommonParams {
 		}
 		if block_number >= self.eip2028_transition {
 			schedule.tx_data_non_zero_gas = 16;
-		}
-		if block_number >= self.eip2200_advance_transition {
-			schedule.sload_gas = 800;
-			schedule.sstore_dirty_gas = Some(800);
 		}
 		if block_number >= self.eip2046_transition {
 			schedule.staticcall_precompile_gas = 40;
@@ -334,10 +328,6 @@ impl From<ethjson::spec::Params> for CommonParams {
 				Into::into,
 			),
 			eip2046_transition: p.eip2046_transition.map_or_else(
-				BlockNumber::max_value,
-				Into::into,
-			),
-			eip2200_advance_transition: p.eip2200_advance_transition.map_or_else(
 				BlockNumber::max_value,
 				Into::into,
 			),

--- a/ethcore/vm/src/schedule.rs
+++ b/ethcore/vm/src/schedule.rs
@@ -53,8 +53,6 @@ pub struct Schedule {
 	pub sha3_word_gas: usize,
 	/// Gas price for loading from storage
 	pub sload_gas: usize,
-	/// Special gas price for dirty gas of SSTORE, after net gas metering.
-	pub sstore_dirty_gas: Option<usize>,
 	/// Gas price for setting new value to storage (`storage==0`, `new!=0`)
 	pub sstore_set_gas: usize,
 	/// Gas price for altering value in storage
@@ -242,7 +240,6 @@ impl Schedule {
 			sha3_gas: 30,
 			sha3_word_gas: 6,
 			sload_gas: 200,
-			sstore_dirty_gas: None,
 			sstore_set_gas: 20000,
 			sstore_reset_gas: 5000,
 			sstore_refund_gas: 15000,
@@ -321,7 +318,7 @@ impl Schedule {
 		schedule.staticcall_precompile_gas = 40; // EIPs 2046 1352
 		schedule
 	}
-	
+
 	fn new(efcd: bool, hdc: bool, tcg: usize) -> Schedule {
 		Schedule {
 			exceptional_failed_code_deposit: efcd,
@@ -341,7 +338,6 @@ impl Schedule {
 			sha3_gas: 30,
 			sha3_word_gas: 6,
 			sload_gas: 50,
-			sstore_dirty_gas: None,
 			sstore_set_gas: 20000,
 			sstore_reset_gas: 5000,
 			sstore_refund_gas: 15000,

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -109,8 +109,6 @@ pub struct Params {
 	/// See `CommonParams` docs.
 	pub eip2046_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	pub eip2200_advance_transition: Option<Uint>,
-	/// See `CommonParams` docs.
 	pub dust_protection_transition: Option<Uint>,
 	/// See `CommonParams` docs.
 	pub nonce_cap_increment: Option<Uint>,


### PR DESCRIPTION
- [x] depends on #11598 removing 2200-advance transition from classic mainnet
- [x] depends on #11529  removing 2200-advance transition from classic testnets

context ref #11347 ref #11474