### PR TITLE
Implement eth/65 (EIP-2464)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,7 @@ dependencies = [
  "snapshot",
  "spec",
  "trace-time",
+ "transaction-pool",
  "triehash-ethereum",
 ]
 

--- a/ethcore/client-traits/src/lib.rs
+++ b/ethcore/client-traits/src/lib.rs
@@ -287,6 +287,9 @@ pub trait BlockChainClient:
 	/// Get transaction with given hash.
 	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction>;
 
+	/// Get pool transaction with a given hash.
+	fn pooled_transaction(&self, hash: H256) -> Option<Arc<VerifiedTransaction>>;
+
 	/// Get uncle with given id.
 	fn uncle(&self, id: UncleId) -> Option<encoded::Header>;
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1889,6 +1889,10 @@ impl BlockChainClient for Client {
 		self.transaction_address(id).and_then(|address| self.chain.read().transaction(&address))
 	}
 
+	fn pooled_transaction(&self, hash: H256) -> Option<Arc<VerifiedTransaction>> {
+		self.importer.miner.transaction(&hash)
+	}
+
 	fn uncle(&self, id: UncleId) -> Option<encoded::Header> {
 		let index = id.position;
 		self.block_body(id.block).and_then(|body| body.view().uncle_rlp_at(index))

--- a/ethcore/src/test_helpers/test_client.rs
+++ b/ethcore/src/test_helpers/test_client.rs
@@ -741,6 +741,9 @@ impl BlockChainClient for TestBlockChainClient {
 	fn transaction(&self, _id: TransactionId) -> Option<LocalizedTransaction> {
 		None	// Simple default.
 	}
+	fn pooled_transaction(&self, _hash: H256) -> Option<Arc<VerifiedTransaction>> {
+		None
+	}
 
 	fn uncle(&self, _id: UncleId) -> Option<encoded::Header> {
 		None	// Simple default.

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -34,6 +34,7 @@ rlp = "0.4.5"
 snapshot = { path = "../snapshot" }
 trace-time = "0.1"
 triehash-ethereum = { version = "0.2", path = "../../util/triehash-ethereum" }
+transaction-pool = "2"
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -26,13 +26,11 @@ use crate::{
 		sync_packet::{
 			PacketInfo,
 			SyncPacket::{
-				self, BlockBodiesPacket, BlockHeadersPacket, NewBlockHashesPacket, NewBlockPacket,
-				PrivateStatePacket, PrivateTransactionPacket, ReceiptsPacket, SignedPrivateTransactionPacket,
-				SnapshotDataPacket, SnapshotManifestPacket, StatusPacket,
+				self, *,
 			}
 		},
 		BlockSet, ChainSync, ForkConfirmation, PacketDecodeError, PeerAsking, PeerInfo, SyncRequester,
-		SyncState, ETH_PROTOCOL_VERSION_63, ETH_PROTOCOL_VERSION_64, MAX_NEW_BLOCK_AGE, MAX_NEW_HASHES,
+		SyncState, ETH_PROTOCOL_VERSION_63, ETH_PROTOCOL_VERSION_64, ETH_PROTOCOL_VERSION_65, MAX_NEW_BLOCK_AGE, MAX_NEW_HASHES,
 		PAR_PROTOCOL_VERSION_1, PAR_PROTOCOL_VERSION_3, PAR_PROTOCOL_VERSION_4,
 	}
 };
@@ -53,6 +51,7 @@ use common_types::{
 	verification::Unverified,
 	snapshot::{ManifestData, RestorationStatus},
 };
+use transaction_pool::VerifiedTransaction;
 
 
 /// The Chain Sync Handler: handles responses from peers
@@ -70,6 +69,8 @@ impl SyncHandler {
 				ReceiptsPacket => SyncHandler::on_peer_block_receipts(sync, io, peer, &rlp),
 				NewBlockPacket => SyncHandler::on_peer_new_block(sync, io, peer, &rlp),
 				NewBlockHashesPacket => SyncHandler::on_peer_new_hashes(sync, io, peer, &rlp),
+				NewPooledTransactionHashesPacket => SyncHandler::on_peer_new_pooled_transactions(sync, io, peer, &rlp),
+				PooledTransactionsPacket => SyncHandler::on_peer_pooled_transactions(sync, io, peer, &rlp),
 				SnapshotManifestPacket => SyncHandler::on_snapshot_manifest(sync, io, peer, &rlp),
 				SnapshotDataPacket => SyncHandler::on_snapshot_data(sync, io, peer, &rlp),
 				PrivateTransactionPacket => SyncHandler::on_private_transaction(sync, io, peer, &rlp),
@@ -590,9 +591,11 @@ impl SyncHandler {
 			difficulty,
 			latest_hash,
 			genesis,
+			unsent_pooled_hashes: if eth_protocol_version >= ETH_PROTOCOL_VERSION_65.0 { Some(io.chain().transactions_to_propagate().into_iter().map(|tx| *tx.hash()).collect()) } else { None },
 			asking: PeerAsking::Nothing,
 			asking_blocks: Vec::new(),
 			asking_hash: None,
+			asking_pooled_transactions: if eth_protocol_version >= ETH_PROTOCOL_VERSION_65.0 { Some(Vec::new()) } else { None },
 			asking_private_state: None,
 			ask_time: Instant::now(),
 			last_sent_transactions: Default::default(),
@@ -651,7 +654,7 @@ impl SyncHandler {
 
 		if false
 			|| (warp_protocol && (peer.protocol_version < PAR_PROTOCOL_VERSION_1.0 || peer.protocol_version > PAR_PROTOCOL_VERSION_4.0))
-			|| (!warp_protocol && (peer.protocol_version < ETH_PROTOCOL_VERSION_63.0 || peer.protocol_version > ETH_PROTOCOL_VERSION_64.0))
+			|| (!warp_protocol && (peer.protocol_version < ETH_PROTOCOL_VERSION_63.0 || peer.protocol_version > ETH_PROTOCOL_VERSION_65.0))
 		{
 			trace!(target: "sync", "Peer {} unsupported eth protocol ({})", peer_id, peer.protocol_version);
 			return Err(DownloaderImportError::Invalid);
@@ -688,6 +691,61 @@ impl SyncHandler {
 
 		let item_count = tx_rlp.item_count()?;
 		trace!(target: "sync", "{:02} -> Transactions ({} entries)", peer_id, item_count);
+		let mut transactions = Vec::with_capacity(item_count);
+		for i in 0 .. item_count {
+			let rlp = tx_rlp.at(i)?;
+			let tx = rlp.as_raw().to_vec();
+			transactions.push(tx);
+		}
+		io.chain().queue_transactions(transactions, peer_id);
+		Ok(())
+	}
+
+	/// Called when peer requests a set of pooled transactions
+	pub fn on_peer_new_pooled_transactions(sync: &mut ChainSync, io: &mut dyn SyncIo, peer_id: PeerId, tx_rlp: &Rlp) -> Result<(), DownloaderImportError> {
+		for item in tx_rlp {
+			let hash = item.as_val::<H256>().map_err(|_| DownloaderImportError::Invalid)?;
+
+			if io.chain().pooled_transaction(hash).is_none() {
+				let unfetched = sync.unfetched_pooled_transactions.entry(hash).or_insert_with(|| super::UnfetchedTransaction {
+					announcer: peer_id,
+					next_fetch: Instant::now(),
+					tries: 0,
+				});
+
+				// Only reset the budget if we hear from multiple sources
+				if unfetched.announcer != peer_id {
+					unfetched.next_fetch = Instant::now();
+					unfetched.tries = 0;
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Called when peer sends us a list of pooled transactions
+	pub fn on_peer_pooled_transactions(sync: &ChainSync, io: &mut dyn SyncIo, peer_id: PeerId, tx_rlp: &Rlp) -> Result<(), DownloaderImportError> {
+		let peer = match sync.peers.get(&peer_id).filter(|p| p.can_sync()) {
+			Some(peer) => peer,
+			None => {
+				trace!(target: "sync", "{} Ignoring transactions from unconfirmed/unknown peer", peer_id);
+				return Ok(());
+			}
+		};
+
+		// TODO: actually check against asked hashes
+		let item_count = tx_rlp.item_count()?;
+		if let Some(p) = &peer.asking_pooled_transactions {
+			if item_count > p.len() {
+				trace!(target: "sync", "{} Peer sent us more transactions than was supposed to", peer_id);
+				return Err(DownloaderImportError::Invalid);
+			}
+		} else {
+			trace!(target: "sync", "{} Peer sent us pooled transactions but does not declare support for them", peer_id);
+			return Err(DownloaderImportError::Invalid);
+		}
+		trace!(target: "sync", "{:02} -> PooledTransactions ({} entries)", peer_id, item_count);
 		let mut transactions = Vec::with_capacity(item_count);
 		for i in 0 .. item_count {
 			let rlp = tx_rlp.at(i)?;

--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -149,6 +149,8 @@ malloc_size_of_is_0!(PeerInfo);
 
 pub type PacketDecodeError = DecoderError;
 
+/// Version 65 of the Ethereum protocol and number of packet IDs reserved by the protocol (packet count).
+pub const ETH_PROTOCOL_VERSION_65: (u8, u8) = (65, 0x11);
 /// Version 64 of the Ethereum protocol and number of packet IDs reserved by the protocol (packet count).
 pub const ETH_PROTOCOL_VERSION_64: (u8, u8) = (64, 0x11);
 /// Version 63 of the Ethereum protocol and number of packet IDs reserved by the protocol (packet count).
@@ -200,6 +202,7 @@ const STATUS_TIMEOUT: Duration = Duration::from_secs(10);
 const HEADERS_TIMEOUT: Duration = Duration::from_secs(15);
 const BODIES_TIMEOUT: Duration = Duration::from_secs(20);
 const RECEIPTS_TIMEOUT: Duration = Duration::from_secs(10);
+const POOLED_TRANSACTIONS_TIMEOUT: Duration = Duration::from_secs(10);
 const FORK_HEADER_TIMEOUT: Duration = Duration::from_secs(3);
 /// Max time to wait for the Snapshot Manifest packet to arrive from a peer after it's being asked.
 const SNAPSHOT_MANIFEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -301,6 +304,7 @@ pub enum PeerAsking {
 	BlockHeaders,
 	BlockBodies,
 	BlockReceipts,
+	PooledTransactions,
 	SnapshotManifest,
 	SnapshotData,
 	PrivateState,
@@ -335,6 +339,8 @@ pub struct PeerInfo {
 	network_id: u64,
 	/// Peer best block hash
 	latest_hash: H256,
+	/// Unpropagated tx pool hashes
+	unsent_pooled_hashes: Option<H256FastSet>,
 	/// Peer total difficulty if known
 	difficulty: Option<U256>,
 	/// Type of data currently being requested by us from a peer.
@@ -343,6 +349,8 @@ pub struct PeerInfo {
 	asking_blocks: Vec<H256>,
 	/// Holds requested header hash if currently requesting block header by hash
 	asking_hash: Option<H256>,
+	/// Holds requested transaction IDs
+	asking_pooled_transactions: Option<Vec<H256>>,
 	/// Holds requested private state hash
 	asking_private_state: Option<H256>,
 	/// Holds requested snapshot chunk hash if any.
@@ -641,6 +649,13 @@ enum PeerState {
 	SameBlock
 }
 
+#[derive(Clone, MallocSizeOf)]
+struct UnfetchedTransaction {
+	announcer: PeerId,
+	next_fetch: Instant,
+	tries: usize,
+}
+
 /// Blockchain sync handler.
 /// See module documentation for more details.
 #[derive(MallocSizeOf)]
@@ -676,6 +691,8 @@ pub struct ChainSync {
 	sync_start_time: Option<Instant>,
 	/// Transactions propagation statistics
 	transactions_stats: TransactionsStats,
+	/// Unfetched transactions
+	unfetched_pooled_transactions: H256FastMap<UnfetchedTransaction>,
 	/// Enable ancient block downloading
 	download_old_blocks: bool,
 	/// Shared private tx service.
@@ -717,6 +734,7 @@ impl ChainSync {
 			snapshot: Snapshot::new(),
 			sync_start_time: None,
 			transactions_stats: TransactionsStats::default(),
+			unfetched_pooled_transactions: Default::default(),
 			private_tx_handler,
 			warp_sync: config.warp_sync,
 			status_sinks: Vec::new()
@@ -730,7 +748,7 @@ impl ChainSync {
 		let last_imported_number = self.new_blocks.last_imported_block_number();
 		SyncStatus {
 			state: self.state.clone(),
-			protocol_version: ETH_PROTOCOL_VERSION_64.0,
+			protocol_version: ETH_PROTOCOL_VERSION_65.0,
 			network_id: self.network_id,
 			start_block_number: self.starting_block,
 			last_imported_block_number: Some(last_imported_number),
@@ -764,8 +782,17 @@ impl ChainSync {
 
 	/// Updates the set of transactions recently sent to this peer to avoid spamming.
 	pub fn transactions_received(&mut self, txs: &[UnverifiedTransaction], peer_id: PeerId) {
-		if let Some(peer_info) = self.peers.get_mut(&peer_id) {
-			peer_info.last_sent_transactions.extend(txs.iter().map(|tx| tx.hash()));
+		for (id, peer) in &mut self.peers {
+			let hashes = txs.iter().map(|tx| tx.hash());
+			if *id == peer_id {
+				peer.last_sent_transactions.extend(hashes);
+			} else if let Some(s) = &mut peer.unsent_pooled_hashes {
+				s.extend(hashes);
+			}
+		}
+
+		for tx in txs {
+			self.unfetched_pooled_transactions.remove(&tx.hash());
 		}
 	}
 
@@ -1099,6 +1126,36 @@ impl ChainSync {
 						}
 					}
 
+					// get some peers to give us transaction pool
+					if !self.unfetched_pooled_transactions.is_empty() {
+						if let Some(s) = &mut self.peers.get_mut(&peer_id).unwrap().asking_pooled_transactions {
+							let now = Instant::now();
+
+							let mut new_asking_pooled_transactions = s.iter().copied().collect::<HashSet<_>>();
+							let mut new_unfetched_pooled_transactions = self.unfetched_pooled_transactions.clone();
+							while new_asking_pooled_transactions.len() <= 256 {
+								for (hash, mut item) in self.unfetched_pooled_transactions.drain() {
+									if item.next_fetch < now {
+										new_asking_pooled_transactions.insert(hash);
+										item.tries += 1;
+										if item.tries < 5 {
+											item.next_fetch = now + (POOLED_TRANSACTIONS_TIMEOUT / 2);
+											new_unfetched_pooled_transactions.insert(hash, item);
+										}
+									}
+								}
+							}
+
+							let new_asking_pooled_transactions = new_asking_pooled_transactions.into_iter().collect::<Vec<_>>();
+							SyncRequester::request_pooled_transactions(self, io, peer_id, &new_asking_pooled_transactions);
+
+							self.peers.get_mut(&peer_id).unwrap().asking_pooled_transactions = Some(new_asking_pooled_transactions);
+							self.unfetched_pooled_transactions = new_unfetched_pooled_transactions;
+
+							return;
+						}
+					}
+
 					// Only ask for old blocks if the peer has an equal or higher difficulty
 					let equal_or_higher_difficulty = peer_difficulty.map_or(true, |pd| pd >= syncing_difficulty);
 
@@ -1290,6 +1347,7 @@ impl ChainSync {
 				PeerAsking::BlockHeaders => elapsed > HEADERS_TIMEOUT,
 				PeerAsking::BlockBodies => elapsed > BODIES_TIMEOUT,
 				PeerAsking::BlockReceipts => elapsed > RECEIPTS_TIMEOUT,
+				PeerAsking::PooledTransactions => elapsed > POOLED_TRANSACTIONS_TIMEOUT,
 				PeerAsking::Nothing => false,
 				PeerAsking::ForkHeader => elapsed > FORK_HEADER_TIMEOUT,
 				PeerAsking::SnapshotManifest => elapsed > SNAPSHOT_MANIFEST_TIMEOUT,
@@ -1618,10 +1676,12 @@ pub mod tests {
 				genesis: H256::zero(),
 				network_id: 0,
 				latest_hash: peer_latest_hash,
+				unsent_pooled_hashes: Some(Default::default()),
 				difficulty: None,
 				asking: PeerAsking::Nothing,
 				asking_blocks: Vec::new(),
 				asking_hash: None,
+				asking_pooled_transactions: Some(Vec::new()),
 				asking_private_state: None,
 				ask_time: Instant::now(),
 				last_sent_transactions: Default::default(),

--- a/ethcore/sync/src/chain/requester.rs
+++ b/ethcore/sync/src/chain/requester.rs
@@ -29,14 +29,7 @@ use rlp::RlpStream;
 use common_types::BlockNumber;
 
 use super::sync_packet::SyncPacket;
-use super::sync_packet::SyncPacket::{
-	GetBlockHeadersPacket,
-	GetBlockBodiesPacket,
-	GetReceiptsPacket,
-	GetSnapshotManifestPacket,
-	GetSnapshotDataPacket,
-	GetPrivateStatePacket,
-};
+use super::sync_packet::SyncPacket::*;
 
 use super::{
 	BlockSet,
@@ -85,6 +78,17 @@ impl SyncRequester {
 		rlp.append(&0u32);
 		rlp.append(&0u32);
 		SyncRequester::send_request(sync, io, peer_id, PeerAsking::ForkHeader, GetBlockHeadersPacket, rlp.out());
+	}
+
+	/// Request pooled transactions from a peer
+	pub fn request_pooled_transactions(sync: &mut ChainSync, io: &mut dyn SyncIo, peer_id: PeerId, hashes: &[H256]) {
+		trace!(target: "sync", "{} <- GetPooledTransactions: {:?}", peer_id, hashes);
+		let mut rlp = RlpStream::new_list(hashes.len());
+		for h in hashes {
+			rlp.append(h);
+		}
+
+		SyncRequester::send_request(sync, io, peer_id, PeerAsking::PooledTransactions, PooledTransactionsPacket, rlp.out())
 	}
 
 	/// Find some headers or blocks to download from a peer.

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -29,25 +29,7 @@ use rlp::{Rlp, RlpStream};
 use common_types::{ids::BlockId, BlockNumber};
 
 use super::sync_packet::{PacketInfo, SyncPacket};
-use super::sync_packet::SyncPacket::{
-	StatusPacket,
-	TransactionsPacket,
-	GetBlockHeadersPacket,
-	BlockHeadersPacket,
-	GetBlockBodiesPacket,
-	BlockBodiesPacket,
-	GetNodeDataPacket,
-	NodeDataPacket,
-	GetReceiptsPacket,
-	ReceiptsPacket,
-	GetSnapshotManifestPacket,
-	SnapshotManifestPacket,
-	GetSnapshotDataPacket,
-	SnapshotDataPacket,
-	ConsensusDataPacket,
-	GetPrivateStatePacket,
-	PrivateStatePacket,
-};
+use super::sync_packet::SyncPacket::*;
 
 use super::{
 	ChainSync,
@@ -74,6 +56,11 @@ impl SyncSupplier {
 
 		if let Some(id) = SyncPacket::from_u8(packet_id) {
 			let result = match id {
+				GetPooledTransactionsPacket => SyncSupplier::return_rlp(
+					io, &rlp, peer,
+					SyncSupplier::return_pooled_transactions,
+					|e| format!("Error sending pooled transactions: {:?}", e)),
+
 				GetBlockBodiesPacket => SyncSupplier::return_rlp(
 					io, &rlp, peer,
 					SyncSupplier::return_block_bodies,
@@ -230,6 +217,24 @@ impl SyncSupplier {
 		rlp.append_raw(&data, count as usize);
 		trace!(target: "sync", "{} -> GetBlockHeaders: returned {} entries", peer_id, count);
 		Ok(Some((BlockHeadersPacket.id(), rlp)))
+	}
+
+	/// Respond to GetPooledTransactions request
+	fn return_pooled_transactions(io: &dyn SyncIo, r: &Rlp, peer_id: PeerId) -> RlpResponseResult {
+		const LIMIT: usize = 256;
+
+		let transactions = r.iter().take(LIMIT).filter_map(|v| {
+			v.as_val::<H256>().ok().and_then(|hash| io.chain().pooled_transaction(hash))
+		}).collect::<Vec<_>>();
+
+		let added = transactions.len();
+		let mut rlp = RlpStream::new_list(added);
+		for tx in transactions {
+			rlp.append(tx.signed());
+		}
+
+		trace!(target: "sync", "{} -> GetPooledTransactions: returned {} entries", peer_id, added);
+		Ok(Some((PooledTransactionsPacket.id(), rlp)))
 	}
 
 	/// Respond to GetBlockBodies request

--- a/ethcore/sync/src/chain/sync_packet.rs
+++ b/ethcore/sync/src/chain/sync_packet.rs
@@ -45,6 +45,9 @@ enum_from_primitive! {
 		GetBlockBodiesPacket = 0x05,
 		BlockBodiesPacket = 0x06,
 		NewBlockPacket = 0x07,
+		NewPooledTransactionHashesPacket = 0x08,
+		GetPooledTransactionsPacket = 0x09,
+		PooledTransactionsPacket = 0x0a,
 
 		GetNodeDataPacket = 0x0d,
 		NodeDataPacket = 0x0e,
@@ -87,6 +90,9 @@ impl PacketInfo for SyncPacket {
 			GetBlockBodiesPacket |
 			BlockBodiesPacket |
 			NewBlockPacket |
+			NewPooledTransactionHashesPacket |
+			GetPooledTransactionsPacket |
+			PooledTransactionsPacket |
 
 			GetNodeDataPacket|
 			NodeDataPacket |

--- a/ethcore/sync/src/tests/helpers.rs
+++ b/ethcore/sync/src/tests/helpers.rs
@@ -25,7 +25,7 @@ use crate::{
 			PacketInfo,
 			SyncPacket::{self, PrivateTransactionPacket, SignedPrivateTransactionPacket}
 		},
-		ChainSync, SyncSupplier, ETH_PROTOCOL_VERSION_64, PAR_PROTOCOL_VERSION_4
+		ChainSync, SyncSupplier, ETH_PROTOCOL_VERSION_65, PAR_PROTOCOL_VERSION_4
 	},
 	private_tx::SimplePrivateTxHandler,
 	sync_io::SyncIo,
@@ -157,7 +157,7 @@ impl<'p, C> SyncIo for TestIo<'p, C> where C: FlushingBlockChainClient, C: 'p {
 	}
 
 	fn protocol_version(&self, protocol: &ProtocolId, _peer_id: PeerId) -> u8 {
-		if protocol == &WARP_SYNC_PROTOCOL_ID { PAR_PROTOCOL_VERSION_4.0 } else { ETH_PROTOCOL_VERSION_64.0 }
+		if protocol == &WARP_SYNC_PROTOCOL_ID { PAR_PROTOCOL_VERSION_4.0 } else { ETH_PROTOCOL_VERSION_65.0 }
 	}
 
 	fn is_expired(&self) -> bool {


### PR DESCRIPTION
This PR adds support for Ethereum protocol version 65 (eth/65) described in [EIP-2464](https://eips.ethereum.org/EIPS/eip-2464). This is a pretty rough draft and can definitely be improved, but I hope the overall direction is good.