### PR TITLE
Add --sync-until=[NUM]

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -304,13 +304,6 @@ impl Importer {
 				// LockedBlock. See https://github.com/openethereum/openethereum/issues/11603
 				let preverified_header = block.header.clone();
 				let hash = block.header.hash();
-				if let Some(sync_until_block_nr) = client.config.sync_until {
-					if block.header.number() > sync_until_block_nr {
-						info!("Sync target reached at block: #{}. Going offline.", sync_until_block_nr);
-						client.disable();
-						break;
-					}
-				}
 
 				let is_invalid = invalid_blocks.contains(block.header.parent_hash());
 				if is_invalid {
@@ -320,6 +313,14 @@ impl Importer {
 
 				match self.check_and_lock_block(block, client) {
 					Ok((locked_block, pending)) => {
+						if let Some(sync_until_block_nr) = client.config.sync_until {
+							if block.header.number() > sync_until_block_nr {
+								info!("Sync target reached at block: #{}. Going offline.", sync_until_block_nr);
+								client.disable();
+								break;
+							}
+						}
+
 						imported_blocks.push(hash);
 						let transactions_len = locked_block.transactions.len();
 						let gas_used = *locked_block.header.gas_used();

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -314,7 +314,7 @@ impl Importer {
 				match self.check_and_lock_block(block, client) {
 					Ok((locked_block, pending)) => {
 						if let Some(sync_until_block_nr) = client.config.sync_until {
-							if block.header.number() > sync_until_block_nr {
+							if locked_block.header.number() > sync_until_block_nr {
 								info!("Sync target reached at block: #{}. Going offline.", sync_until_block_nr);
 								client.disable();
 								break;

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -304,6 +304,13 @@ impl Importer {
 				// LockedBlock. See https://github.com/openethereum/openethereum/issues/11603
 				let preverified_header = block.header.clone();
 				let hash = block.header.hash();
+				if let Some(sync_until_block_nr) = client.config.sync_until {
+					if block.header.number() > sync_until_block_nr {
+						info!("Sync target reached at block: #{}. Going offline.", sync_until_block_nr);
+						client.disable();
+						break;
+					}
+				}
 
 				let is_invalid = invalid_blocks.contains(block.header.parent_hash());
 				if is_invalid {

--- a/ethcore/src/client/config.rs
+++ b/ethcore/src/client/config.rs
@@ -94,6 +94,8 @@ pub struct ClientConfig {
 	pub max_round_blocks_to_import: usize,
 	/// Snapshot configuration
 	pub snapshot: SnapshotConfiguration,
+	/// Stop importing at this block and enter sleep mode.
+	pub sync_until: Option<u64>,
 }
 
 impl Default for ClientConfig {
@@ -122,6 +124,7 @@ impl Default for ClientConfig {
 			transaction_verification_queue_size: 8192,
 			max_round_blocks_to_import: 12,
 			snapshot: Default::default(),
+			sync_until: None,
 		}
 	}
 }

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -358,6 +358,7 @@ fn execute_import(cmd: ImportBlockchain) -> Result<(), String> {
 		cmd.pruning_memory,
 		cmd.check_seal,
 		12,
+		None,
 	);
 
 	client_config.queue.verifier_settings = cmd.verifier_settings;
@@ -494,6 +495,7 @@ fn start_client(
 		pruning_memory,
 		true,
 		max_round_blocks_to_import,
+		None // todo[dvdplm]
 	);
 
 	let restoration_db_handler = db::restoration_db_handler(&client_path, &client_config);

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -495,7 +495,7 @@ fn start_client(
 		pruning_memory,
 		true,
 		max_round_blocks_to_import,
-		None // todo[dvdplm]
+		None
 	);
 
 	let restoration_db_handler = db::restoration_db_handler(&client_path, &client_config);

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -318,6 +318,10 @@ usage! {
 			"--db-path=[PATH]",
 			"Specify the database directory path",
 
+			ARG arg_sync_until: (Option<u64>) = None, or |c: &Config| c.parity.as_ref()?.sync_until.clone(),
+			"--sync-until=[NUM]",
+			"Stop syncing and enter offline mode  when the given block has been imported.",
+
 		["Convenience Options"]
 			FLAG flag_unsafe_expose: (bool) = false, or |c: &Config| c.misc.as_ref()?.unsafe_expose,
 			"--unsafe-expose",
@@ -1171,6 +1175,7 @@ struct Operating {
 	light: Option<bool>,
 	no_persistent_txqueue: Option<bool>,
 	no_hardcoded_sync: Option<bool>,
+	sync_until: Option<u64>,
 
 	#[serde(rename = "public_node")]
 	_legacy_public_node: Option<bool>,
@@ -1734,6 +1739,7 @@ mod tests {
 			flag_no_hardcoded_sync: false,
 			flag_no_persistent_txqueue: false,
 			flag_force_direct: false,
+			arg_sync_until: None,
 
 			// -- Convenience Options
 			arg_config: "$BASE/config.toml".into(),
@@ -2014,6 +2020,7 @@ mod tests {
 				light: None,
 				no_hardcoded_sync: None,
 				no_persistent_txqueue: None,
+				sync_until: None,
 				_legacy_public_node: None,
 			}),
 			account: Some(Account {

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -2020,7 +2020,7 @@ mod tests {
 				light: None,
 				no_hardcoded_sync: None,
 				no_persistent_txqueue: None,
-				sync_until: None,
+				sync_until: Some(123),
 				_legacy_public_node: None,
 			}),
 			account: Some(Account {

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -320,7 +320,7 @@ usage! {
 
 			ARG arg_sync_until: (Option<u64>) = None, or |c: &Config| c.parity.as_ref()?.sync_until.clone(),
 			"--sync-until=[NUM]",
-			"Stop syncing and enter offline mode when the given block has been imported.",
+			"Sync until the given block has been imported, then enter offline mode. Intended for debug/benchmarking only.",
 
 		["Convenience Options"]
 			FLAG flag_unsafe_expose: (bool) = false, or |c: &Config| c.misc.as_ref()?.unsafe_expose,

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -320,7 +320,7 @@ usage! {
 
 			ARG arg_sync_until: (Option<u64>) = None, or |c: &Config| c.parity.as_ref()?.sync_until.clone(),
 			"--sync-until=[NUM]",
-			"Stop syncing and enter offline mode  when the given block has been imported.",
+			"Stop syncing and enter offline mode when the given block has been imported.",
 
 		["Convenience Options"]
 			FLAG flag_unsafe_expose: (bool) = false, or |c: &Config| c.misc.as_ref()?.unsafe_expose,

--- a/parity/cli/tests/config.toml
+++ b/parity/cli/tests/config.toml
@@ -3,6 +3,7 @@ mode = "dark"
 mode_timeout = 15
 mode_alarm = 10
 chain = "./chain.json"
+sync_until = 123
 
 [account]
 unlock = ["0x1", "0x2", "0x3"]

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -413,6 +413,7 @@ impl Configuration {
 				on_demand_request_backoff_max: self.args.arg_on_demand_request_backoff_max,
 				on_demand_request_backoff_rounds_max: self.args.arg_on_demand_request_backoff_rounds_max,
 				on_demand_request_consecutive_failures: self.args.arg_on_demand_request_consecutive_failures,
+				sync_until: self.args.arg_sync_until,
 			};
 			Cmd::Run(run_cmd)
 		};
@@ -1453,6 +1454,7 @@ mod tests {
 			on_demand_request_backoff_max: None,
 			on_demand_request_backoff_rounds_max: None,
 			on_demand_request_consecutive_failures: None,
+			sync_until: None,
 		};
 		expected.secretstore_conf.enabled = cfg!(feature = "secretstore");
 		expected.secretstore_conf.http_enabled = cfg!(feature = "secretstore");

--- a/parity/helpers.rs
+++ b/parity/helpers.rs
@@ -240,6 +240,7 @@ pub fn to_client_config(
 	pruning_memory: usize,
 	check_seal: bool,
 	max_round_blocks_to_import: usize,
+	sync_until: Option<u64>,
 ) -> ClientConfig {
 	let mut client_config = ClientConfig::default();
 
@@ -273,6 +274,7 @@ pub fn to_client_config(
 	client_config.verifier_type = if check_seal { VerifierType::Canon } else { VerifierType::CanonNoSeal };
 	client_config.spec_name = spec_name;
 	client_config.max_round_blocks_to_import = max_round_blocks_to_import;
+	client_config.sync_until = sync_until;
 	client_config
 }
 

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -137,6 +137,7 @@ pub struct RunCmd {
 	pub on_demand_request_backoff_max: Option<u64>,
 	pub on_demand_request_backoff_rounds_max: Option<usize>,
 	pub on_demand_request_consecutive_failures: Option<usize>,
+	pub sync_until: Option<u64>,
 }
 
 // node info fetcher for the local store.
@@ -538,6 +539,7 @@ fn execute_impl<Cr, Rr>(
 		cmd.pruning_memory,
 		cmd.check_seal,
 		cmd.max_round_blocks_to_import,
+		cmd.sync_until,
 	);
 
 	client_config.queue.verifier_settings = cmd.verifier_settings;

--- a/parity/snapshot_cmd.rs
+++ b/parity/snapshot_cmd.rs
@@ -186,6 +186,7 @@ impl SnapshotCommand {
 			self.pruning_memory,
 			true,
 			self.max_round_blocks_to_import,
+			None,
 		);
 
 		client_config.snapshot = self.snapshot_conf;


### PR DESCRIPTION
Add an option `--sync-until` to halt syncing at a given block number. This is useful
when benchmarking or debugging and you want to sync the chain to a
predetermined block. The alternative today is to have scripts and poll
the node using RPCs and use `db reset` to get to the desired state.