### PR TITLE
Upgrade num to 0.2, use enum-primitive-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
- "num-traits 0.2.11",
+ "num-traits",
  "time",
 ]
 
@@ -718,7 +718,7 @@ dependencies = [
  "csv",
  "itertools",
  "lazy_static",
- "num-traits 0.2.11",
+ "num-traits",
  "oorandom",
  "plotters",
  "rayon",
@@ -989,12 +989,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum_primitive"
-version = "0.1.1"
+name = "enum-primitive-derive"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
+checksum = "5f52288f9a7ebb08959188872b58e7eaa12af9cb47da8e94158e16da7e143340"
 dependencies = [
- "num-traits 0.1.43",
+ "num-traits",
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1045,8 +1047,8 @@ dependencies = [
  "eth_pairings_repr_derive",
  "fixed_width_field",
  "fixed_width_group_and_loop",
- "num-bigint 0.2.6",
- "num-traits 0.2.11",
+ "num-bigint",
+ "num-traits",
  "once_cell",
  "static_assertions",
 ]
@@ -1576,7 +1578,7 @@ dependencies = [
  "client-traits",
  "common-types",
  "engine",
- "enum_primitive",
+ "enum-primitive-derive",
  "env_logger 0.5.13",
  "ethcore",
  "ethcore-io",
@@ -1593,6 +1595,7 @@ dependencies = [
  "kvdb-memorydb",
  "log",
  "machine",
+ "num-traits",
  "parity-bytes",
  "parity-crypto",
  "parity-runtime",
@@ -3043,26 +3046,16 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.42"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
- "num-bigint 0.1.44",
+ "num-bigint",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-traits 0.2.11",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-dependencies = [
- "num-integer",
- "num-traits 0.2.11",
- "rand 0.4.6",
- "rustc-serialize",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -3073,7 +3066,17 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
- "num-traits 0.2.11",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -3083,7 +3086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -3094,16 +3097,19 @@ checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.1.43"
+name = "num-rational"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "num-traits 0.2.11",
+ "autocfg 1.0.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3131,7 +3137,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"
 dependencies = [
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -3774,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
 dependencies = [
  "js-sys",
- "num-traits 0.2.11",
+ "num-traits",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -4348,12 +4354,6 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"

--- a/ethcore/builtin/Cargo.toml
+++ b/ethcore/builtin/Cargo.toml
@@ -14,7 +14,7 @@ ethereum-types = "0.9.0"
 ethjson = { path = "../../json" }
 keccak-hash = "0.5.0"
 log = "0.4"
-num = { version = "0.1", default-features = false, features = ["bigint"] }
+num = "0.2"
 parity-bytes = "0.1"
 parity-crypto = { version = "0.6.1", features = ["publickey"] }
 eth_pairings = { git = "https://github.com/matter-labs/eip1962.git", default-features = false, features = ["eip_2537"], rev = "ece6cbabc41948db4200e41f0bfdab7ab94c7af8" }

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { package = "parity-bytes", version = "0.1" }
 client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
 devp2p = { package = "ethcore-network-devp2p", path = "../../util/network-devp2p" }
-enum_primitive = "0.1.1"
+enum-primitive-derive = "0.2"
 ethcore-io = { path = "../../util/io" }
 ethcore-private-tx = { path = "../private-tx" }
 ethereum-forkid = "0.2"
@@ -25,6 +25,7 @@ keccak-hash = "0.5.0"
 light = { package = "ethcore-light", path = "../light" }
 log = "0.4"
 network = { package = "ethcore-network", path = "../../util/network" }
+num-traits = "0.2"
 parity-runtime = "0.1.1"
 parity-crypto = { version = "0.6.1", features = ["publickey"] }
 parity-util-mem = "0.6.0"

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 
 use bytes::Bytes;
-use enum_primitive::FromPrimitive;
+use num_traits::FromPrimitive;
 use ethereum_types::{H256, U256};
 use keccak_hash::keccak;
 use network::PeerId;

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 use crate::sync_io::SyncIo;
 
 use bytes::Bytes;
-use enum_primitive::FromPrimitive;
+use num_traits::FromPrimitive;
 use ethereum_types::H256;
 use log::{debug, trace, warn};
 use network::{self, PeerId};

--- a/ethcore/sync/src/chain/sync_packet.rs
+++ b/ethcore/sync/src/chain/sync_packet.rs
@@ -25,42 +25,40 @@
 use crate::api::{ETH_PROTOCOL, WARP_SYNC_PROTOCOL_ID};
 use self::SyncPacket::*;
 
-use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
+use enum_primitive_derive::Primitive;
 use network::{PacketId, ProtocolId};
 
-enum_from_primitive! {
-	/// An enum that defines all known packet ids in the context of
-	/// synchronization and provides a mechanism to convert from
-	/// packet ids (of type PacketId or u8) directly read from the network
-	/// to enum variants. This implicitly provides a mechanism to
-	/// check whether a given packet id is known, and to prevent
-	/// packet id clashes when defining new ids.
-	#[derive(Clone, Copy, Debug, PartialEq)]
-	pub enum SyncPacket {
-		StatusPacket = 0x00,
-		NewBlockHashesPacket = 0x01,
-		TransactionsPacket = 0x02,
-		GetBlockHeadersPacket = 0x03,
-		BlockHeadersPacket = 0x04,
-		GetBlockBodiesPacket = 0x05,
-		BlockBodiesPacket = 0x06,
-		NewBlockPacket = 0x07,
+/// An enum that defines all known packet ids in the context of
+/// synchronization and provides a mechanism to convert from
+/// packet ids (of type PacketId or u8) directly read from the network
+/// to enum variants. This implicitly provides a mechanism to
+/// check whether a given packet id is known, and to prevent
+/// packet id clashes when defining new ids.
+#[derive(Clone, Copy, Debug, PartialEq, Primitive)]
+pub enum SyncPacket {
+	StatusPacket = 0x00,
+	NewBlockHashesPacket = 0x01,
+	TransactionsPacket = 0x02,
+	GetBlockHeadersPacket = 0x03,
+	BlockHeadersPacket = 0x04,
+	GetBlockBodiesPacket = 0x05,
+	BlockBodiesPacket = 0x06,
+	NewBlockPacket = 0x07,
 
-		GetNodeDataPacket = 0x0d,
-		NodeDataPacket = 0x0e,
-		GetReceiptsPacket = 0x0f,
-		ReceiptsPacket = 0x10,
+	GetNodeDataPacket = 0x0d,
+	NodeDataPacket = 0x0e,
+	GetReceiptsPacket = 0x0f,
+	ReceiptsPacket = 0x10,
 
-		GetSnapshotManifestPacket = 0x11,
-		SnapshotManifestPacket = 0x12,
-		GetSnapshotDataPacket = 0x13,
-		SnapshotDataPacket = 0x14,
-		ConsensusDataPacket = 0x15,
-		PrivateTransactionPacket = 0x16,
-		SignedPrivateTransactionPacket = 0x17,
-		GetPrivateStatePacket = 0x18,
-		PrivateStatePacket = 0x19,
-	}
+	GetSnapshotManifestPacket = 0x11,
+	SnapshotManifestPacket = 0x12,
+	GetSnapshotDataPacket = 0x13,
+	SnapshotDataPacket = 0x14,
+	ConsensusDataPacket = 0x15,
+	PrivateTransactionPacket = 0x16,
+	SignedPrivateTransactionPacket = 0x17,
+	GetPrivateStatePacket = 0x18,
+	PrivateStatePacket = 0x19,
 }
 
 
@@ -118,7 +116,7 @@ impl PacketInfo for SyncPacket {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use enum_primitive::FromPrimitive;
+	use num_traits::FromPrimitive;
 
 	#[test]
 	fn packet_ids_from_u8_when_from_primitive_zero_then_equals_status_packet() {


### PR DESCRIPTION
This was highlighted during the AllCoreDevs call. num 0.1 is too slow and thus blocks the [proposed repricing of ModExp precompile](https://eips.ethereum.org/EIPS/eip-2565). enum-primitive is unmaintained, so switched to enum-primitive-derive which is based on num 0.2.