### PR TITLE
Deploy docker images on master

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -3,7 +3,7 @@ name:                           Docker Image Release
 on:
   push:
     branches:
-      - stable
+      - master
     tags:
       - v*
 


### PR DESCRIPTION
Previously it was defined to deploy on tags and stable branch. Stable branch is not used so, the stable branch nowadays is master.