### PR TITLE
Add git binary to first docker stage for generating proper log headers

### DIFF
--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache \
   linux-headers \
   perl \
   rust \
+  git \
   clang-dev \
   llvm-dev
 


### PR DESCRIPTION
Previous PR https://github.com/openethereum/openethereum/pull/11608 seems to not be enough.

Checking the vergen library repo https://github.com/rustyhorde/vergen#note-on-semver found that it relies on the git binary to extract the values of .git folder

This should solve the UNKNOWN values on the log header