### PR TITLE
Drain the transaction overlay

### DIFF
--- a/ethcore/snapshot/src/lib.rs
+++ b/ethcore/snapshot/src/lib.rs
@@ -435,6 +435,12 @@ impl StateRebuilder {
 			}
 		}
 
+		let backing = self.db.backing().clone();
+		let mut batch = backing.transaction();
+		// Drain the transaction overlay and put the data into the batch.
+		self.db.inject(&mut batch)?;
+		backing.write_buffered(batch);
+
 		Ok(())
 	}
 


### PR DESCRIPTION
When restoring a chunk during warp sync, drain the transaction overlay. 
Fixes memory blowup seen after https://github.com/openethereum/openethereum/pull/11589 landed.

There's a discussion to be had about the [semantics of the implementations of `inject()`](https://github.com/openethereum/openethereum/blob/master/util/journaldb/src/overlayrecentdb.rs#L400) and [its docs](https://github.com/openethereum/openethereum/blob/master/util/journaldb/src/lib.rs#L72-L79). It can have significant side-effects beyond injecting independent extra database ops into a batch of writes.