### PR TITLE
Replace parity-snappy with snap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,15 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "common-types"
 version = "0.1.0"
 dependencies = [
@@ -659,12 +650,12 @@ dependencies = [
  "keccak-hash",
  "parity-bytes",
  "parity-crypto",
- "parity-snappy",
  "parity-util-mem",
  "patricia-trie-ethereum",
  "rlp",
  "rlp-derive",
  "rustc-hex 2.1.0",
+ "snap",
  "unexpected",
  "vm",
 ]
@@ -1418,11 +1409,11 @@ dependencies = [
  "lazy_static",
  "libc",
  "parity-crypto",
- "parity-snappy",
  "rlp",
  "semver",
  "serde",
  "serde_derive",
+ "snap",
 ]
 
 [[package]]
@@ -1450,7 +1441,6 @@ dependencies = [
  "parity-bytes",
  "parity-crypto",
  "parity-path",
- "parity-snappy",
  "parking_lot 0.10.0",
  "rand 0.7.3",
  "rlp",
@@ -1458,6 +1448,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slab",
+ "snap",
  "tempfile",
  "tiny-keccak 2.0.2",
 ]
@@ -3465,26 +3456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-snappy"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c5f9d149b13134b8b354d93a92830efcbee6fe5b73a2e6e540fe70d4dd8a63"
-dependencies = [
- "libc",
- "parity-snappy-sys",
-]
-
-[[package]]
-name = "parity-snappy-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a413d51e5e1927320c9de992998e4a279dffb8c8a7363570198bd8383e66f1b"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "parity-tokio-ipc"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4573,6 +4544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
+name = "snap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fb9b0bb877b35a1cc1474a3b43d9c226a2625311760cdda2cbccbc0c7a8376"
+
+[[package]]
 name = "snapshot"
 version = "0.1.0"
 dependencies = [
@@ -4604,7 +4581,6 @@ dependencies = [
  "log",
  "num_cpus",
  "parity-bytes",
- "parity-snappy",
  "parking_lot 0.10.0",
  "patricia-trie-ethereum",
  "rand 0.7.3",
@@ -4612,6 +4588,7 @@ dependencies = [
  "rlp",
  "rlp-derive",
  "scopeguard 1.1.0",
+ "snap",
  "snapshot-tests",
  "spec",
  "tempfile",
@@ -4649,12 +4626,12 @@ dependencies = [
  "log",
  "parity-bytes",
  "parity-crypto",
- "parity-snappy",
  "parking_lot 0.10.0",
  "patricia-trie-ethereum",
  "rand 0.7.3",
  "rand_xorshift 0.2.0",
  "rlp",
+ "snap",
  "snapshot",
  "spec",
  "tempfile",

--- a/ethcore/snapshot/Cargo.toml
+++ b/ethcore/snapshot/Cargo.toml
@@ -36,7 +36,7 @@ parking_lot = "0.10.0"
 rlp = "0.4.5"
 rlp-derive = "0.1"
 scopeguard = "1.1.0"
-snappy = { package = "parity-snappy", version ="0.1.0" }
+snap = "1"
 trie-db = "0.20.0"
 triehash = { package = "triehash-ethereum", version = "0.2",  path = "../../util/triehash-ethereum" }
 

--- a/ethcore/snapshot/snapshot-tests/Cargo.toml
+++ b/ethcore/snapshot/snapshot-tests/Cargo.toml
@@ -31,7 +31,7 @@ parity-crypto = { version = "0.6.1", features = ["publickey"] }
 rand = "0.7.3"
 rand_xorshift = "0.2.0"
 rlp = "0.4.5"
-snappy = { package = "parity-snappy", version ="0.1.0" }
+snap = "1"
 snapshot = { path = "../../snapshot", features = ["test-helpers"] }
 spec = { path = "../../spec" }
 tempfile = "3.1"

--- a/ethcore/snapshot/snapshot-tests/src/proof_of_work.rs
+++ b/ethcore/snapshot/snapshot-tests/src/proof_of_work.rs
@@ -32,7 +32,6 @@ use snapshot::{
 	PowSnapshot,
 };
 use parking_lot::{Mutex, RwLock};
-use snappy;
 use keccak_hash::KECCAK_NULL_RLP;
 use kvdb::DBTransaction;
 use ethcore::test_helpers;
@@ -97,7 +96,7 @@ fn chunk_and_restore(amount: u64) {
 	let flag = AtomicBool::new(true);
 	for chunk_hash in &reader.manifest().block_hashes {
 		let compressed = reader.chunk(*chunk_hash).unwrap();
-		let chunk = snappy::decompress(&compressed).unwrap();
+		let chunk = snap::raw::Decoder::new().decompress_vec(&compressed).unwrap();
 		rebuilder.feed(&chunk, engine.as_ref(), &flag).unwrap();
 	}
 

--- a/ethcore/snapshot/snapshot-tests/src/state.rs
+++ b/ethcore/snapshot/snapshot-tests/src/state.rs
@@ -86,7 +86,7 @@ fn snap_and_restore() {
 
 		for chunk_hash in &reader.manifest().state_hashes {
 			let raw = reader.chunk(*chunk_hash).unwrap();
-			let chunk = snappy::decompress(&raw).unwrap();
+			let chunk = snap::raw::Decoder::new().decompress_vec(&raw).unwrap();
 
 			rebuilder.feed(&chunk, &flag).unwrap();
 		}
@@ -210,7 +210,7 @@ fn checks_flag() {
 
 		for chunk_hash in &reader.manifest().state_hashes {
 			let raw = reader.chunk(*chunk_hash).unwrap();
-			let chunk = snappy::decompress(&raw).unwrap();
+			let chunk = snap::raw::Decoder::new().decompress_vec(&raw).unwrap();
 
 			match rebuilder.feed(&chunk, &flag) {
 				Err(Error::Snapshot(SnapshotError::RestorationAborted)) => {},

--- a/ethcore/types/Cargo.toml
+++ b/ethcore/types/Cargo.toml
@@ -15,10 +15,10 @@ ethjson = { path = "../../json" }
 hash = { package = "keccak-hash", version = "0.5" }
 parity-crypto = { version = "0.6.1", features = ["publickey"] }
 parity-util-mem = "0.6.0"
-parity-snappy = "0.1"
 ethtrie = { package = "patricia-trie-ethereum", path = "../../util/patricia-trie-ethereum" }
 rlp = "0.4.5"
 rlp-derive = "0.1"
+snap = "1"
 unexpected = { path = "../../util/unexpected" }
 vm = { path = "../vm"}
 

--- a/ethcore/types/src/errors/ethcore_error.rs
+++ b/ethcore/types/src/errors/ethcore_error.rs
@@ -24,7 +24,6 @@ use std::{error, fmt};
 use derive_more::{Display, From};
 use ethereum_types::{U256, U512};
 use ethtrie::TrieError;
-use parity_snappy::InvalidInput;
 use parity_crypto::publickey::Error as EthPublicKeyCryptoError;
 
 /// Ethcore Result
@@ -59,7 +58,7 @@ pub enum EthcoreError {
 	Transaction(TransactionError),
 	/// Snappy error
 	#[display(fmt = "Snappy error: {}", _0)]
-	Snappy(InvalidInput),
+	Snappy(snap::Error),
 	/// Consensus vote error.
 	#[display(fmt = "Engine error: {}", _0)]
 	Engine(EngineError),

--- a/ethcore/types/src/errors/snapshot_error.rs
+++ b/ethcore/types/src/errors/snapshot_error.rs
@@ -70,6 +70,8 @@ pub enum SnapshotError {
 	WrongChunkFormat(String),
 	/// Unlinked ancient block chain; includes the parent hash where linkage failed
 	UnlinkedAncientBlockChain(H256),
+	/// Compression error
+	CompressionError(snap::Error),
 }
 
 impl error::Error for SnapshotError {
@@ -87,7 +89,7 @@ impl error::Error for SnapshotError {
 impl fmt::Display for SnapshotError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		use self::SnapshotError::*;
-		match *self {
+		match self {
 			InvalidStartingBlock(ref id) => write!(f, "Invalid starting block: {:?}", id),
 			BlockNotFound(ref hash) => write!(f, "Block not found in chain: {}", hash),
 			IncompleteChain => write!(f, "Incomplete blockchain."),
@@ -111,6 +113,7 @@ impl fmt::Display for SnapshotError {
 			BadEpochProof(i) => write!(f, "Bad epoch proof for transition to epoch {}", i),
 			WrongChunkFormat(ref msg) => write!(f, "Wrong chunk format: {}", msg),
 			UnlinkedAncientBlockChain(parent_hash) => write!(f, "Unlinked ancient blocks chain at parent_hash={:#x}", parent_hash),
+			CompressionError(err) => write!(f, "Compression error: {}", err),
 		}
 	}
 }
@@ -130,6 +133,12 @@ impl From<TrieError> for SnapshotError {
 impl From<DecoderError> for SnapshotError {
 	fn from(err: DecoderError) -> Self {
 		SnapshotError::Decoder(err)
+	}
+}
+
+impl From<snap::Error> for SnapshotError {
+	fn from(err: snap::Error) -> Self {
+		SnapshotError::CompressionError(err)
 	}
 }
 

--- a/util/network-devp2p/Cargo.toml
+++ b/util/network-devp2p/Cargo.toml
@@ -26,7 +26,6 @@ network = { package = "ethcore-network", path = "../network" }
 parity-bytes = "0.1"
 parity-crypto = { version = "0.6.1", features = ["publickey"] }
 parity-path = "0.1"
-parity-snappy = "0.1"
 parking_lot = "0.10.0"
 rand = "0.7.3"
 rlp = "0.4.5"
@@ -34,6 +33,7 @@ secp256k1 = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slab = "0.4.2"
+snap = "1"
 tiny-keccak = "2.0.2"
 
 [dev-dependencies]

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -15,10 +15,10 @@ ipnetwork = "0.12.6"
 lazy_static = "1.0"
 rlp = "0.4.5"
 libc = "0.2"
-parity-snappy = "0.1"
 semver = {version="0.9.0", features=["serde"]}
 serde = "1.0"
 serde_derive = "1.0"
+snap = "1"
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/util/network/src/error.rs
+++ b/util/network/src/error.rs
@@ -17,7 +17,6 @@
 use std::{error, io, net, fmt};
 use libc::{ENFILE, EMFILE};
 use io::IoError;
-use {rlp, crypto, snappy};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DisconnectReason
@@ -87,7 +86,7 @@ pub enum Error {
 	/// Socket IO error.
 	SocketIo(IoError),
 	/// Decompression error.
-	Decompression(snappy::InvalidInput),
+	Decompression(snap::Error),
 	/// Rlp decoder error.
 	Rlp(rlp::DecoderError),
 	/// Error concerning the network address parsing subsystem.
@@ -160,8 +159,8 @@ impl From<IoError> for Error {
 	}
 }
 
-impl From<snappy::InvalidInput> for Error {
-	fn from(err: snappy::InvalidInput) -> Self {
+impl From<snap::Error> for Error {
+	fn from(err: snap::Error) -> Self {
 		Error::Decompression(err)
 	}
 }

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -21,10 +21,10 @@ extern crate ethcore_io as io;
 extern crate ethereum_types;
 extern crate rlp;
 extern crate ipnetwork;
-extern crate parity_snappy as snappy;
 extern crate libc;
 extern crate semver;
 extern crate serde;
+extern crate snap;
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Had trouble compiling parity-snappy under MSYS2, so decided to take a look at the native Rust replacement. [Performance should be identical to bindings](https://github.com/BurntSushi/rust-snappy#performance).