### PR TITLE
Use nightly tag for master branch

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -28,3 +28,4 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: scripts/docker/alpine/Dockerfile
           tag_names: true
+          tags: "nightly"


### PR DESCRIPTION
Right now we are using the default latest for master branch and is a bit confusing for user. 
With this PR, it pushes nightly and only latest for tagged commits

Reference: https://github.com/elgohr/Publish-Docker-Github-Action/pull/89