### PR TITLE
Fix alpine docker image entry point

### DIFF
--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -45,4 +45,4 @@ WORKDIR /home/openethereum
 RUN mkdir -p /home/openethereum/.local/share/io.parity.ethereum/
 COPY --chown=openethereum:openethereum --from=builder /openethereum/target/x86_64-alpine-linux-musl/release/openethereum ./
 
-ENTRYPOINT ["./openethereum"]
+ENTRYPOINT ["/home/openethereum/openethereum"]

--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -26,12 +26,13 @@ FROM alpine:edge
 # show backtraces
 ENV RUST_BACKTRACE 1
 
-# curl is installed to help create health and readiness checks on Kubernetes
+# curl and jq are installed to help create health and readiness checks on Kubernetes
 RUN apk add --no-cache \
   libstdc++ \
   eudev-libs \
   libgcc \
-  curl
+  curl \
+  jq
 
 RUN addgroup -g 1000 openethereum \
   && adduser -u 1000 -G openethereum -s /bin/sh -D openethereum


### PR DESCRIPTION
Alpine docker image uses relative path at entrypoint, it breaks compatibility with parity image, I get an error while running `openethereum/openethereum` container with `workdir` changed to non-default value
```
Error response from daemon: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"./openethereum\": stat ./openethereum: no such file or directory": unknown
```