### PR TITLE
ethcore/private-tcx: fix deadlock caused by conflicting lock order

### DIFF
--- a/ethcore/private-tx/src/state_store.rs
+++ b/ethcore/private-tx/src/state_store.rs
@@ -90,11 +90,11 @@ impl PrivateStateStorage {
 			request_hashes: request_hashes.clone(),
 			state: RequestState::Syncing,
 		};
+		let mut hashes = self.syncing_hashes.write();
 		let mut requests = self.requests.write();
 		requests.push(request);
 		let mut new_hashes = Vec::new();
 		for hash in request_hashes {
-			let mut hashes = self.syncing_hashes.write();
 			if hashes.insert(hash, Instant::now() + Duration::from_millis(MAX_REQUEST_SESSION_DURATION)).is_none() {
 				new_hashes.push(hash);
 			}


### PR DESCRIPTION
This PR fixes a deadlock caused by conflicting lock order in ethcore/private-tcx/src/state_store.rs
|add_request|state_sync_completed|
|---|---|
|requests.write()||
||syncing_hashes.write()|
||mark_hash_ready()|
||requests.write()//deadlock!|
|syncing_hashes.write()//deadlock!||

https://github.com/openethereum/openethereum/blob/1b0bbd50a4b75d25b52961f34dcccd5836a07c97/ethcore/private-tx/src/state_store.rs#L75-L79
https://github.com/openethereum/openethereum/blob/1b0bbd50a4b75d25b52961f34dcccd5836a07c97/ethcore/private-tx/src/state_store.rs#L93-L97

The fix is to lift the `syncing_hashes.write()` before `requests.write()` in `add_request()`.
But I am not sure if this lock order is correct.