### PR TITLE
ethcore/light: fix deadlock caused by conflicting lock order

### DIFF
--- a/ethcore/light/src/client/header_chain.rs
+++ b/ethcore/light/src/client/header_chain.rs
@@ -823,10 +823,8 @@ impl HeaderChain {
 	/// The header corresponding the the parent hash must be stored already.
 	pub fn epoch_transition_for(&self, parent_hash: H256) -> Option<(Header, Vec<u8>)> {
 		// slow path: loop back block by block
-		let live_proofs = self.live_epoch_proofs.read();
-
 		for hdr in self.ancestry_iter(BlockId::Hash(parent_hash)) {
-			if let Some(transition) = live_proofs.get(&hdr.hash()).cloned() {
+			if let Some(transition) = self.live_epoch_proofs.read().get(&hdr.hash()).cloned() {
 				return hdr.decode().map(|decoded_hdr| {
 					(decoded_hdr, transition.proof)
 				}).ok();


### PR DESCRIPTION
Similar to #11766,

|epoch_transition_for|insert_inner|
|---|---|
|live_epoch_proofs.read()||
|ancestry_iter||
|block_header||
||candidates.write()|
|candidates.read()||
||live_epoch_proofs.write()|

https://github.com/openethereum/openethereum/blob/f8cbdadfaaef30febbeab1ec5b7331a74ec7856a/ethcore/light/src/client/header_chain.rs#L824-L829
https://github.com/openethereum/openethereum/blob/f8cbdadfaaef30febbeab1ec5b7331a74ec7856a/ethcore/light/src/client/header_chain.rs#L744
https://github.com/openethereum/openethereum/blob/f8cbdadfaaef30febbeab1ec5b7331a74ec7856a/ethcore/light/src/client/header_chain.rs#L699
https://github.com/openethereum/openethereum/blob/f8cbdadfaaef30febbeab1ec5b7331a74ec7856a/ethcore/light/src/client/header_chain.rs#L410
https://github.com/openethereum/openethereum/blob/f8cbdadfaaef30febbeab1ec5b7331a74ec7856a/ethcore/light/src/client/header_chain.rs#L514

The fix is to move `live_proofs` below `ancestry_iter`. I am not very sure about this fix since it changes the critical section a lot.