### PR TITLE
Use BigUint::modpow for ModExp precompile

### DIFF
--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -1121,7 +1121,6 @@ mod tests {
 	};
 	use hex_literal::hex;
 	use maplit::btreemap;
-	use num::{BigUint, Zero, One};
 	use parity_bytes::BytesRef;
 	use super::{
 		Builtin, EthereumBuiltin, FromStr, Implementation, Linear,

--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -772,7 +772,11 @@ impl Implementation for Modexp {
 			let exponent = read_num(&mut reader, exp_len);
 			let modulus = read_num(&mut reader, mod_len);
 
-			base.modpow(&exponent, &modulus)
+			if modulus.is_zero() || modulus.is_one() {
+				BigUint::zero()
+			} else {
+				base.modpow(&exponent, &modulus)
+			}
 		};
 
 		// write output to given memory, left padded and same length as the modulus.

--- a/ethcore/builtin/src/lib.rs
+++ b/ethcore/builtin/src/lib.rs
@@ -738,54 +738,6 @@ impl Implementation for Ripemd160 {
 	}
 }
 
-// calculate modexp: left-to-right binary exponentiation to keep multiplicands lower
-fn modexp(mut base: BigUint, exp: Vec<u8>, modulus: BigUint) -> BigUint {
-	const BITS_PER_DIGIT: usize = 8;
-
-	// n^m % 0 || n^m % 1
-	if modulus <= BigUint::one() {
-		return BigUint::zero();
-	}
-
-	// normalize exponent
-	let mut exp = exp.into_iter().skip_while(|d| *d == 0).peekable();
-
-	// n^0 % m
-	if exp.peek().is_none() {
-		return BigUint::one();
-	}
-
-	// 0^n % m, n > 0
-	if base.is_zero() {
-		return BigUint::zero();
-	}
-
-	base %= &modulus;
-
-	// Fast path for base divisible by modulus.
-	if base.is_zero() { return BigUint::zero() }
-
-	// Left-to-right binary exponentiation (Handbook of Applied Cryptography - Algorithm 14.79).
-	// http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf
-	let mut result = BigUint::one();
-
-	for digit in exp {
-		let mut mask = 1 << (BITS_PER_DIGIT - 1);
-
-		for _ in 0..BITS_PER_DIGIT {
-			result = &result * &result % &modulus;
-
-			if digit & mask > 0 {
-				result = result * &base % &modulus;
-			}
-
-			mask >>= 1;
-		}
-	}
-
-	result
-}
-
 impl Implementation for Modexp {
 	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), &'static str> {
 		let mut reader = input.chain(io::repeat(0));
@@ -817,13 +769,10 @@ impl Implementation for Modexp {
 			};
 
 			let base = read_num(&mut reader, base_len);
-
-			let mut exp_buf = vec![0; exp_len];
-			reader.read_exact(&mut exp_buf[..exp_len]).expect("reading from zero-extended memory cannot fail; qed");
-
+			let exponent = read_num(&mut reader, exp_len);
 			let modulus = read_num(&mut reader, mod_len);
 
-			modexp(base, exp_buf, modulus)
+			base.modpow(&exponent, &modulus)
 		};
 
 		// write output to given memory, left padded and same length as the modulus.
@@ -1172,7 +1121,7 @@ mod tests {
 	use parity_bytes::BytesRef;
 	use super::{
 		Builtin, EthereumBuiltin, FromStr, Implementation, Linear,
-		ModexpPricer, modexp as me, Pricing,
+		ModexpPricer, Pricing,
 		Bls12ConstOperations,
 		Bls12PairingPrice,Bls12PairingPricer
 	};
@@ -1294,39 +1243,6 @@ mod tests {
 		let mut out = [0u8; 64];
 		blake2.execute(&input[..], &mut BytesRef::Fixed(&mut out[..])).unwrap();
 		assert_eq!(&out[..], &expected[..]);
-	}
-
-	#[test]
-	fn modexp_func() {
-		// n^0 % m == 1
-		let mut base = BigUint::parse_bytes(b"12345", 10).unwrap();
-		let mut exp = BigUint::zero();
-		let mut modulus = BigUint::parse_bytes(b"789", 10).unwrap();
-		assert_eq!(me(base, exp.to_bytes_be(), modulus), BigUint::one());
-
-		// 0^n % m == 0
-		base = BigUint::zero();
-		exp = BigUint::parse_bytes(b"12345", 10).unwrap();
-		modulus = BigUint::parse_bytes(b"789", 10).unwrap();
-		assert_eq!(me(base, exp.to_bytes_be(), modulus), BigUint::zero());
-
-		// n^m % 1 == 0
-		base = BigUint::parse_bytes(b"12345", 10).unwrap();
-		exp = BigUint::parse_bytes(b"789", 10).unwrap();
-		modulus = BigUint::one();
-		assert_eq!(me(base, exp.to_bytes_be(), modulus), BigUint::zero());
-
-		// if n % d == 0, then n^m % d == 0
-		base = BigUint::parse_bytes(b"12345", 10).unwrap();
-		exp = BigUint::parse_bytes(b"789", 10).unwrap();
-		modulus = BigUint::parse_bytes(b"15", 10).unwrap();
-		assert_eq!(me(base, exp.to_bytes_be(), modulus), BigUint::zero());
-
-		// others
-		base = BigUint::parse_bytes(b"12345", 10).unwrap();
-		exp = BigUint::parse_bytes(b"789", 10).unwrap();
-		modulus = BigUint::parse_bytes(b"97", 10).unwrap();
-		assert_eq!(me(base, exp.to_bytes_be(), modulus), BigUint::parse_bytes(b"55", 10).unwrap());
 	}
 
 	#[test]


### PR DESCRIPTION
Switches ModExp precompile implementation to use BigUint::modpow, should be faster per #11714 