### PR TITLE
Trigger custom docker build when adding ci-build-docker to the commit

### DIFF
--- a/.github/workflows/deploy-docker-custom-message.yml
+++ b/.github/workflows/deploy-docker-custom-message.yml
@@ -23,3 +23,4 @@ jobs:
           dockerfile: scripts/docker/alpine/Dockerfile
           tag_names: false
           tags: "testing/${{ env.GITHUB_REF }}"
+

--- a/.github/workflows/deploy-docker-custom-message.yml
+++ b/.github/workflows/deploy-docker-custom-message.yml
@@ -22,5 +22,5 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: scripts/docker/alpine/Dockerfile
           tag_names: false
-          tags: "alpha-${{ env.GITHUB_REF }}"
+          tags: "${{ env.GITHUB_REF }}"
 

--- a/.github/workflows/deploy-docker-custom-message.yml
+++ b/.github/workflows/deploy-docker-custom-message.yml
@@ -1,4 +1,4 @@
-name:                           Docker Image Release
+name:                           Docker Image Release - Custom Version
 on: push
 jobs:
   deploy-docker:

--- a/.github/workflows/deploy-docker-custom-message.yml
+++ b/.github/workflows/deploy-docker-custom-message.yml
@@ -22,4 +22,4 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: scripts/docker/alpine/Dockerfile
           tag_names: false
-          tags: "${{ env.GITHUB_REF }}"
+          tags: "testing/${{ env.GITHUB_REF }}"

--- a/.github/workflows/deploy-docker-custom-message.yml
+++ b/.github/workflows/deploy-docker-custom-message.yml
@@ -22,5 +22,5 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: scripts/docker/alpine/Dockerfile
           tag_names: false
-          tags: "testing/${{ env.GITHUB_REF }}"
+          tags: "alpha-${{ env.GITHUB_REF }}"
 

--- a/.github/workflows/deploy-docker-custom-message.yml
+++ b/.github/workflows/deploy-docker-custom-message.yml
@@ -1,0 +1,25 @@
+name:                           Docker Image Release
+on: push
+jobs:
+  deploy-docker:
+    name:                       Build Docker Image for Custom Branches
+    if: "contains(github.event.head_commit.message, 'ci-build-docker')"
+    runs-on:                    ubuntu-latest
+    steps:
+      - name:                   Checkout sources
+        uses:                   actions/checkout@master
+      - name:                   Install toolchain
+        uses:                   actions-rs/toolchain@v1
+        with:
+          toolchain:            stable
+          profile:              minimal
+          override:             true
+      - name:                   Deploy to docker hub
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: openethereum/openethereum
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: scripts/docker/alpine/Dockerfile
+          tag_names: false
+          tags: "${{ env.GITHUB_REF }}"


### PR DESCRIPTION
There are times when we need to build docker images for testing, like in this branch https://github.com/openethereum/openethereum/tree/adria0/prometheus before merging to master.

With this action, this is easier and only triggered on demand.

It publishes the image in the docker hub https://hub.docker.com/r/openethereum/openethereum/tags with the branch name prefixed by "alpha-"