### PR TITLE
Update parity-crypto dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,9 +3291,9 @@ checksum = "16b56e3a2420138bdb970f84dfb9c774aea80fa0e7371549eedec0d80c209c67"
 
 [[package]]
 name = "parity-crypto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7f19c1acc7fc6c5256a2f4f0c5af022044b9bdfdd0a218ff79f8cbb29779a5"
+checksum = "88e15b5e11d7a4829490630a797c537a68c9e864a139f56fe7a1e6a51f0da25d"
 dependencies = [
  "aes",
  "aes-ctr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ num_cpus = "1.2"
 number_prefix = "0.2"
 panic_hook = { path = "util/panic-hook" }
 parity-bytes = "0.1"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parity-daemonize = "0.3"
 parity-hash-fetch = { path = "updater/hash-fetch" }
 parity-local-store = { path = "miner/local-store" }

--- a/accounts/Cargo.toml
+++ b/accounts/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 ethkey = { path = "ethkey" }
 ethstore = { path = "ethstore" }
 log = "0.4"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parking_lot = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/accounts/ethkey/Cargo.toml
+++ b/accounts/ethkey/Cargo.toml
@@ -9,5 +9,5 @@ edit-distance = "2.0"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parity-wordlist = "1.3.1"

--- a/accounts/ethkey/cli/Cargo.toml
+++ b/accounts/ethkey/cli/Cargo.toml
@@ -9,7 +9,7 @@ docopt = "1.0"
 env_logger = "0.5"
 ethkey = { path = "../" }
 panic_hook = { path = "../../../util/panic-hook" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parity-wordlist= "1.3.1"
 rustc-hex = "2.1.0"
 serde = "1.0"

--- a/accounts/ethstore/Cargo.toml
+++ b/accounts/ethstore/Cargo.toml
@@ -17,7 +17,7 @@ rustc-hex = "2.1.0"
 tiny-keccak = "2.0.2"
 time = "0.1.34"
 parking_lot = "0.10.0"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 ethereum-types = "0.9.0"
 dir = { path = "../../util/dir" }
 smallvec = "1.2.0"

--- a/accounts/ethstore/cli/Cargo.toml
+++ b/accounts/ethstore/cli/Cargo.toml
@@ -14,7 +14,7 @@ serde_derive = "1.0"
 parking_lot = "0.10.0"
 ethstore = { path = "../" }
 ethkey = { path = "../../ethkey" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 dir = { path = '../../../util/dir' }
 panic_hook = { path = "../../../util/panic-hook" }
 

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -42,7 +42,7 @@ parity-bytes = "0.1"
 parking_lot = "0.10.0"
 pod = { path = "pod", optional = true }
 trie-db = "0.20.0"
-parity-crypto = { version = "0.6.1", features = ["publickey"], optional = true }
+parity-crypto = { version = "0.6.2", features = ["publickey"], optional = true }
 patricia-trie-ethereum = { path = "../util/patricia-trie-ethereum" }
 rand = "0.7.3"
 rand_xorshift = "0.2.0"
@@ -75,7 +75,7 @@ env_logger = "0.5"
 ethcore-accounts = { path = "../accounts" }
 ethcore-builtin = { path = "./builtin" }
 ethjson = { path = "../json", features = ["test-helpers"] }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 fetch = { path = "../util/fetch" }
 kvdb-memorydb = "0.5.0"
 kvdb-rocksdb = "0.7.0"

--- a/ethcore/blockchain/Cargo.toml
+++ b/ethcore/blockchain/Cargo.toml
@@ -29,7 +29,7 @@ triehash-ethereum = { version = "0.2",  path = "../../util/triehash-ethereum" }
 
 [dev-dependencies]
 env_logger = "0.5"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 rustc-hex = "2.1.0"
 tempfile = "3.1"
 kvdb-memorydb = "0.5.0"

--- a/ethcore/builtin/Cargo.toml
+++ b/ethcore/builtin/Cargo.toml
@@ -16,7 +16,7 @@ keccak-hash = "0.5.0"
 log = "0.4"
 num = "0.2"
 parity-bytes = "0.1"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 eth_pairings = { git = "https://github.com/matter-labs/eip1962.git", default-features = false, features = ["eip_2537"], rev = "ece6cbabc41948db4200e41f0bfdab7ab94c7af8" }
 
 [dev-dependencies]

--- a/ethcore/engine/Cargo.toml
+++ b/ethcore/engine/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { package = "parity-bytes", version = "0.1.0" }
 client-traits = { path = "../client-traits" }
 common-types = { path = "../types" }
 ethereum-types = "0.9.0"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 machine = { path = "../machine" }
 vm = { path = "../vm" }
 

--- a/ethcore/engines/authority-round/Cargo.toml
+++ b/ethcore/engines/authority-round/Cargo.toml
@@ -17,7 +17,7 @@ ethabi-contract = "11.0"
 ethabi-derive = "12.0"
 ethereum-types = "0.9.0"
 ethjson = { path = "../../../json" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 engine = { path = "../../engine" }
 io = { package = "ethcore-io", path = "../../../util/io" }
 itertools = "0.8.2"

--- a/ethcore/engines/basic-authority/Cargo.toml
+++ b/ethcore/engines/basic-authority/Cargo.toml
@@ -12,7 +12,7 @@ common-types = { path = "../../types" }
 engine = { path = "../../engine" }
 ethereum-types = "0.9.0"
 ethjson = { path = "../../../json" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 log = "0.4.8"
 machine = { path = "../../machine" }
 parking_lot = "0.10.0"

--- a/ethcore/engines/clique/Cargo.toml
+++ b/ethcore/engines/clique/Cargo.toml
@@ -11,7 +11,7 @@ client-traits = { path = "../../client-traits" }
 common-types = { path = "../../types" }
 ethereum-types = "0.9.0"
 ethjson = { path = "../../../json" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 engine = { path = "../../engine" }
 keccak-hash = "0.5.0"
 lazy_static = "1.3.0"

--- a/ethcore/engines/validator-set/Cargo.toml
+++ b/ethcore/engines/validator-set/Cargo.toml
@@ -38,7 +38,7 @@ env_logger = "0.6.2"
 ethcore = { path = "../..", features = ["test-helpers"] }
 rustc-hex = "2.1.0"
 keccak-hash = "0.5.0"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 spec = { path = "../../spec" }
 
 [features]

--- a/ethcore/executive-state/Cargo.toml
+++ b/ethcore/executive-state/Cargo.toml
@@ -28,7 +28,7 @@ vm = { path = "../vm" }
 [dev-dependencies]
 env_logger = "0.5"
 ethcore = { path = "..", features = ["test-helpers"] }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 evm = { path = "../evm" }
 keccak-hash = "0.5.0"
 pod = { path = "../pod" }

--- a/ethcore/machine/Cargo.toml
+++ b/ethcore/machine/Cargo.toml
@@ -43,7 +43,7 @@ criterion = "0.3"
 ethcore = { path = "../", features = ["test-helpers"] }
 ethcore-io = { path = "../../util/io" }
 ethjson = { path = "../../json" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 hex-literal = "0.2.1"
 spec = { path = "../spec" }
 tempfile = "3.1"

--- a/ethcore/private-tx/Cargo.toml
+++ b/ethcore/private-tx/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 machine = { path = "../machine" }
 journaldb = { path = "../../util/journaldb" }
 parity-bytes = "0.1"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parking_lot = "0.10.0"
 trie-db = "0.20.0"
 patricia-trie-ethereum = { path = "../../util/patricia-trie-ethereum" }

--- a/ethcore/snapshot/snapshot-tests/Cargo.toml
+++ b/ethcore/snapshot/snapshot-tests/Cargo.toml
@@ -27,7 +27,7 @@ kvdb = "0.5.0"
 kvdb-rocksdb = "0.7.0"
 log = "0.4.8"
 parking_lot = "0.10.0"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 rand = "0.7.3"
 rand_xorshift = "0.2.0"
 rlp = "0.4.5"

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 network = { package = "ethcore-network", path = "../../util/network" }
 num-traits = "0.2"
 parity-runtime = "0.1.1"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parity-util-mem = "0.6.0"
 rand = "0.7.3"
 parking_lot = "0.10.0"

--- a/ethcore/types/Cargo.toml
+++ b/ethcore/types/Cargo.toml
@@ -13,7 +13,7 @@ ethcore-io = { path = "../../util/io" }
 ethereum-types = "0.9.0"
 ethjson = { path = "../../json" }
 hash = { package = "keccak-hash", version = "0.5" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parity-util-mem = "0.6.0"
 ethtrie = { package = "patricia-trie-ethereum", path = "../../util/patricia-trie-ethereum" }
 rlp = "0.4.5"

--- a/ethcore/verification/Cargo.toml
+++ b/ethcore/verification/Cargo.toml
@@ -35,7 +35,7 @@ unexpected = { path = "../../util/unexpected" }
 common-types = { path = "../types", features = ["test-helpers"] }
 criterion = "0.3"
 ethcore = { path = "../", features = ["test-helpers"] }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 machine = { path = "../machine" }
 null-engine = { path = "../engines/null-engine" }
 spec = { path = "../spec" }

--- a/ethcore/wasm/Cargo.toml
+++ b/ethcore/wasm/Cargo.toml
@@ -10,7 +10,7 @@ ethereum-types = "0.9.0"
 log = "0.4"
 parity-wasm = "0.31"
 libc = "0.2"
-pwasm-utils = "0.6.1"
+pwasm-utils = "0.6.2"
 vm = { path = "../vm" }
 wasmi = "0.3.0"
 

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -39,7 +39,7 @@ transaction-pool = "2.0.1"
 
 [dev-dependencies]
 env_logger = "0.5"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 rustc-hex = "2.1.0"
 
 [features]

--- a/miner/local-store/Cargo.toml
+++ b/miner/local-store/Cargo.toml
@@ -17,5 +17,5 @@ serde_json = "1.0"
 
 [dev-dependencies]
 ethkey = { path = "../../accounts/ethkey" }
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 kvdb-memorydb = "0.5.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -49,7 +49,7 @@ ethereum-types = "0.9.0"
 fastmap = { path = "../util/fastmap" }
 machine = { path = "../ethcore/machine" }
 parity-bytes = "0.1"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 
 eip-712 = { path = "../util/EIP-712" }
 ethjson = { path = "../json" }

--- a/util/network-devp2p/Cargo.toml
+++ b/util/network-devp2p/Cargo.toml
@@ -24,7 +24,7 @@ mio = "0.6.8"
 natpmp = "0.2"
 network = { package = "ethcore-network", path = "../network" }
 parity-bytes = "0.1"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 parity-path = "0.1"
 parking_lot = "0.10.0"
 rand = "0.7.3"

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 derive_more = "0.99"
-parity-crypto = { version = "0.6.1", features = ["publickey"] }
+parity-crypto = { version = "0.6.2", features = ["publickey"] }
 ethcore-io = { path = "../io" }
 ethereum-types = "0.9.0"
 ipnetwork = "0.12.6"


### PR DESCRIPTION
This PR updates parity-crypto dependency from 0.6.1 to 0.6.2 (https://github.com/paritytech/parity-common/blob/master/parity-crypto/CHANGELOG.md).


