### PR TITLE
Add deploy zip artifacts to AWS S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     env:
       SCCACHE_CACHE_SIZE:       "1G"
       SCCACHE_IDLE_TIMEOUT:     0
+      AWS_S3_ARTIFACTS_BUCKET:  "openethereum-releases"
+      AWS_REGION:               "us-east-1"
     strategy:
       matrix:
         platform:
@@ -200,9 +202,10 @@ jobs:
           echo ::set-output name=WINDOWS_ARTIFACT::openethereum-windows-${{ env.RELEASE_VERSION }}.zip
           echo ::set-output name=WINDOWS_SHASUM::$(shasum -a 256 openethereum-windows-${{ env.RELEASE_VERSION }}.zip | awk '{print $1}')
 
-      # ==============================
-      #       Upload artifacts
-      # ==============================
+      # =======================================================================
+      # Upload artifacts
+      # This is required to share artifacts between different jobs
+      # =======================================================================
 
       - name:                   Upload artifacts
         uses:                   actions/upload-artifact@v2
@@ -221,6 +224,24 @@ jobs:
         with:
           name:                 openethereum-windows-${{ env.RELEASE_VERSION }}.zip
           path:                 openethereum-windows-${{ env.RELEASE_VERSION }}.zip
+
+      # =======================================================================
+      # Upload artifacts to S3
+      # This is required by some software distribution systems which require
+      # artifacts to be downloadable, like Brew on MacOS.
+      # =======================================================================
+      - name:                   Configure AWS credentials
+        uses:                   aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ env.AWS_REGION }}
+
+      - name:                   Copy files to S3 with the AWS CLI
+        run: |
+          # Deploy zip artifacts to S3 bucket to a directory whose name is the tagged release version.
+          # If deletion of files not available on "." (local directory) is required, add --delete to the aws-cli command below.
+          aws s3 sync . s3://${{ env.AWS_S3_ARTIFACTS_BUCKET }}/${{ env.RELEASE_VERSION }} --include "*.zip"
 
     outputs:
       linux-artifact:           ${{ steps.create_zip_linux.outputs.LINUX_ARTIFACT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,8 +240,8 @@ jobs:
       - name:                   Copy files to S3 with the AWS CLI
         run: |
           # Deploy zip artifacts to S3 bucket to a directory whose name is the tagged release version.
-          # If deletion of files not available on "." (local directory) is required, add --delete to the aws-cli command below.
-          aws s3 sync . s3://${{ env.AWS_S3_ARTIFACTS_BUCKET }}/${{ env.RELEASE_VERSION }} --include "*.zip"
+          # Deploy macos binary artifact (if required, add more `aws s3 cp` commands to deploy specific OS versions)
+          aws s3 cp macos-artifacts/openethereum s3://${{ env.AWS_S3_ARTIFACTS_BUCKET }}/${{ env.RELEASE_VERSION }}/macos/
 
     outputs:
       linux-artifact:           ${{ steps.create_zip_linux.outputs.LINUX_ARTIFACT }}


### PR DESCRIPTION
This PR adds the ability to deploy zip artifacts (compiled OpenEthereum binary files) to AWS S3.
Having artifacts on a website, namely S3 bucket, is required by several operating system's package managers like Brew.

No modifications to codebase are involved, only modifications to Github Actions workflows. 
