### PR TITLE
Disable warp sync snapshotting by default

### DIFF
--- a/ethcore/snapshot/src/lib.rs
+++ b/ethcore/snapshot/src/lib.rs
@@ -95,8 +95,8 @@ const MAX_SNAPSHOT_SUBPARTS: usize = 256;
 /// Configuration for the Snapshot service
 #[derive(Debug, Clone, PartialEq)]
 pub struct SnapshotConfiguration {
-	/// If `true`, no periodic snapshots will be created
-	pub no_periodic: bool,
+	/// Enable creation of periodic snapshots
+	pub enable: bool,
 	/// Number of threads for creating snapshots
 	pub processing_threads: usize,
 }
@@ -104,7 +104,7 @@ pub struct SnapshotConfiguration {
 impl Default for SnapshotConfiguration {
 	fn default() -> Self {
 		SnapshotConfiguration {
-			no_periodic: false,
+			enable: false,
 			processing_threads: ::std::cmp::max(1, num_cpus::get_physical() / 2),
 		}
 	}

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -910,9 +910,9 @@ usage! {
 			"Skip block seal check.",
 
 		["Snapshot Options"]
-			FLAG flag_no_periodic_snapshot: (bool) = false, or |c: &Config| c.snapshots.as_ref()?.disable_periodic.clone(),
-			"--no-periodic-snapshot",
-			"Disable automated snapshots which usually occur once every 5000 blocks.",
+			FLAG flag_enable_snapshotting: (bool) = false, or |c: &Config| c.snapshots.as_ref()?.enable.clone(),
+			"--enable-snapshotting",
+			"Enable automated snapshots which usually occur once every 5000 blocks.",
 
 			ARG arg_snapshot_threads: (Option<usize>) = None, or |c: &Config| c.snapshots.as_ref()?.processing_threads,
 			"--snapshot-threads=[NUM]",
@@ -1396,7 +1396,7 @@ struct Footprint {
 #[derive(Default, Debug, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Snapshots {
-	disable_periodic: Option<bool>,
+	enable: Option<bool>,
 	processing_threads: Option<usize>,
 }
 
@@ -1913,7 +1913,7 @@ mod tests {
 			// -- Snapshot Optons
 			arg_export_state_at: "latest".into(),
 			arg_snapshot_at: "latest".into(),
-			flag_no_periodic_snapshot: false,
+			flag_enable_snapshotting: false,
 			arg_snapshot_threads: None,
 
 			// -- Light options.
@@ -2178,7 +2178,7 @@ mod tests {
 				on_demand_request_consecutive_failures: Some(1),
 			}),
 			snapshots: Some(Snapshots {
-				disable_periodic: Some(true),
+				enable: Some(false),
 				processing_threads: None,
 			}),
 			misc: Some(Misc {

--- a/parity/cli/tests/config.full.toml
+++ b/parity/cli/tests/config.full.toml
@@ -160,7 +160,7 @@ on_demand_request_backoff_rounds_max = 100
 on_demand_request_consecutive_failures = 1
 
 [snapshots]
-disable_periodic = false
+enable = false
 
 [misc]
 logging = "own_tx=trace"

--- a/parity/cli/tests/config.toml
+++ b/parity/cli/tests/config.toml
@@ -76,7 +76,7 @@ on_demand_request_backoff_rounds_max = 10
 on_demand_request_consecutive_failures = 1
 
 [snapshots]
-disable_periodic = true
+enable = false
 
 [misc]
 logging = "own_tx=trace"

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -925,7 +925,7 @@ impl Configuration {
 
 	fn snapshot_config(&self) -> Result<SnapshotConfiguration, String> {
 		let mut conf = SnapshotConfiguration::default();
-		conf.no_periodic = self.args.flag_no_periodic_snapshot;
+		conf.enable = self.args.flag_enable_snapshotting;
 		if let Some(threads) = self.args.arg_snapshot_threads {
 			if threads > 0 {
 				conf.processing_threads = threads;


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/240364/86982064-06662e80-c191-11ea-98ef-6415838ca238.png)

Warp sync snapshotting takes quite a lot of RAM. This may make OpenEthereum unusable on many otherwise fine configurations. More than that, snapshotting by laymen may be unnecessary because:
- For public networks we maintain perfectly capable warp-sync-ready bootnodes.
- For private networks it makes more sense to simply backup the database and restore the chain database to the nodes verbatim.