### PR TITLE
Add CORS Max-Age header of 600 seconds

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -162,6 +162,9 @@ pub use http_common::HttpMetaExtractor;
 
 use std::net::SocketAddr;
 
+/// RPC HTTP Server header Access-Control-Max-Age
+const CORS_MAX_AGE_SECONDS: u32 = 600;
+
 /// RPC HTTP Server instance
 pub type HttpServer = http::Server;
 
@@ -186,6 +189,7 @@ pub fn start_http<M, S, H, T>(
 		.keep_alive(keep_alive)
 		.threads(threads)
 		.cors(cors_domains)
+		.cors_max_age(CORS_MAX_AGE_SECONDS)
 		.allowed_hosts(allowed_hosts)
 		.health_api(("/api/health", "parity_nodeStatus"))
 		.cors_allow_headers(AccessControlAllowHeaders::Any)
@@ -217,6 +221,7 @@ pub fn start_http_with_middleware<M, S, H, T, R>(
 		.keep_alive(keep_alive)
 		.threads(threads)
 		.cors(cors_domains)
+		.cors_max_age(CORS_MAX_AGE_SECONDS)
 		.allowed_hosts(allowed_hosts)
 		.cors_allow_headers(AccessControlAllowHeaders::Any)
 		.max_request_body_size(max_payload * 1024 * 1024)


### PR DESCRIPTION
This PR adds a CORS `Access-Control-Max-Age` of `600` seconds to RPC pre-flight `OPTIONS` responses.

Original issue #8542 was closed a year later as being implemented in https://github.com/paritytech/jsonrpc/pull/280, but that was (and still is) [disabled by default](https://github.com/paritytech/jsonrpc/blob/dfa6b98304f52a8fa9e3c4d03f68152dbb770f1d/http/src/lib.rs#L365-L372), so this was never actually resolved.

The value of `600` seconds matches [Geth's implementation](https://github.com/ethereum/go-ethereum/blob/5b081ab214d8d6373cbfdd9464f2503934b9bb68/node/rpcstack.go#L45-L50).

Fixes #8542.