### PR TITLE
Bump memory-db lib to 0.24.1 and add shrink_to_fit #11760 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,13 +2852,12 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.21.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e20981dbe8b148b10d6151f448f5e38c5eed9f50a44599e4a70edb5c4f5aec"
+checksum = "36f36ddb0b2cdc25d38babba472108798e3477f02be5165f038c5e393e50c57a"
 dependencies = [
- "ahash 0.2.18",
  "hash-db",
- "hashbrown 0.6.3",
+ "hashbrown 0.8.0",
  "parity-util-mem",
 ]
 

--- a/ethcore/account-state/Cargo.toml
+++ b/ethcore/account-state/Cargo.toml
@@ -19,7 +19,7 @@ keccak-hasher = { path = "../../util/keccak-hasher" }
 kvdb = "0.7"
 log = "0.4"
 lru-cache = "0.1.2"
-memory-db = "0.21.1"
+memory-db = "0.24.1"
 parity-bytes = "0.1.0"
 parity-util-mem = "0.7"
 parking_lot = "0.10.0"

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -18,7 +18,7 @@ ethcore-blockchain = { path = "../blockchain" }
 ethereum-types = "0.9.2"
 executive-state = { path = "../executive-state" }
 machine = { path = "../machine" }
-memory-db = "0.21.1"
+memory-db = "0.24.1"
 trie-db = "0.21.0"
 patricia-trie-ethereum = { path = "../../util/patricia-trie-ethereum" }
 ethcore-network = { path = "../../util/network" }

--- a/util/journaldb/Cargo.toml
+++ b/util/journaldb/Cargo.toml
@@ -14,7 +14,7 @@ parity-util-mem = "0.7"
 keccak-hasher = { path = "../keccak-hasher" }
 kvdb = "0.7"
 log = "0.4"
-memory-db = "0.21.1"
+memory-db = "0.24.1"
 parking_lot = "0.10.0"
 fastmap = { path = "../../util/fastmap" }
 rlp = "0.4.5"

--- a/util/journaldb/src/overlayrecentdb.rs
+++ b/util/journaldb/src/overlayrecentdb.rs
@@ -253,7 +253,7 @@ impl JournalDB for OverlayRecentDB {
 		let mut mem = self.transaction_overlay.size_of(&mut ops);
 		let overlay = self.journal_overlay.read();
 
-		mem += overlay.cumulative_size; //This does not present real HashMap memory footprint but we are doing shrink_to_size after removal so this is good approximation.
+		mem += overlay.backing_overlay.size_of(&mut ops);
 		mem += overlay.pending_overlay.size_of(&mut ops);
 		mem += overlay.journal.size_of(&mut ops);
 

--- a/util/patricia-trie-ethereum/Cargo.toml
+++ b/util/patricia-trie-ethereum/Cargo.toml
@@ -15,7 +15,7 @@ ethereum-types = "0.9.2"
 elastic-array = "0.10"
 
 [dev-dependencies]
-memory-db = "0.21.1"
+memory-db = "0.24.1"
 keccak-hash = "0.5.0"
 journaldb = { path = "../journaldb" }
 criterion = "0.3"


### PR DESCRIPTION
- Mostly fixes that help to resolve the issue: #11760 
- Bump `memory-db lib` to `0.24.1` and add shrink_to_fit
- Upgraded some trace log to info when pruning happens
- Use `overlay.cumulative_size` instead of `overlay.backing_overlay.size_of(..)` It is more inaccurate but it is good enough and a it will allow us to skip heavy `size_of`.