### PR TITLE
Missing EIP transitions for dev chain spec

### DIFF
--- a/ethcore/res/instant_seal.json
+++ b/ethcore/res/instant_seal.json
@@ -27,6 +27,11 @@
 		"eip145Transition": "0x0",
 		"eip1014Transition": "0x0",
 		"eip1052Transition": "0x0",
+		"eip1283Transition": "0x0",
+		"eip1344Transition": "0x0",
+		"eip1706Transition": "0x0",
+		"eip1884Transition": "0x0",
+		"eip2028Transition": "0x0",
 		"wasmActivationTransition": "0x0"
 	},
 	"genesis": {


### PR DESCRIPTION
I found the missing EIP transitions when testing a contract using the `SELFBALANCE` instruction. I don't see most of these in the docs, but they are present in the `foundation.json` chain spec. Most of these are related to the Istanbul hard fork