### PR TITLE
Update Ellaism Chainspec

### DIFF
--- a/ethcore/res/ethereum/ellaism.json
+++ b/ethcore/res/ethereum/ellaism.json
@@ -28,7 +28,6 @@
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
 		"eip155Transition": "0x0",
-		"wasmActivationTransition": 2000000,
 		"eip140Transition": 2000000,
 		"eip211Transition": 2000000,
 		"eip214Transition": 2000000,


### PR DESCRIPTION
Ellaism is removing the Parity Wasm capability. A full archive sync was run without the option enabled and there were no issues. Additionally all deployed contracts where verified to not be a Wasm contract.