### PR TITLE
WIP: Add script to build Docker alpine container from project root directory

### DIFF
--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -2,6 +2,18 @@
 
 ```docker build -f docker/ubuntu/Dockerfile --tag ethcore/openethereum:branch_or_tag_name .```
 
+## Usage - Alpine
+
+Builds a lightweight non-root OpenEthereum docker image:
+```
+git clone https://github.com/openethereum/openethereum.git
+cd openethereum
+
+OPENETHEREUM_IMAGE_REPO=eth1.0:openethereum \
+OPENETHEREUM_IMAGE_TAG=eth1.0-openethereum \
+./scripts/docker/alpine/build.sh
+```
+
 ## Usage - CentOS
 
 Builds a lightweight non-root OpenEthereum docker image:

--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -46,4 +46,5 @@ WORKDIR /home/openethereum
 RUN mkdir -p /home/openethereum/.local/share/io.parity.ethereum/
 COPY --chown=openethereum:openethereum --from=builder /openethereum/target/x86_64-alpine-linux-musl/release/openethereum ./
 
-ENTRYPOINT ["/home/openethereum/openethereum"]
+# prevent Docker container from stopping after running it
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/scripts/docker/alpine/build.sh
+++ b/scripts/docker/alpine/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+# The image name
+OPENETHEREUM_IMAGE_REPO=${OPENETHEREUM_IMAGE_REPO}
+# The tag to be used for the image
+OPENETHEREUM_BUILDER_IMAGE_TAG=${OPENETHEREUM_IMAGE_TAG}
+
+echo Building $OPENETHEREUM_IMAGE_REPO:
+docker build -t $OPENETHEREUM_IMAGE_REPO . -f scripts/docker/alpine/Dockerfile
+
+echo Running OpenEthereum:
+docker run -d --name $OPENETHEREUM_IMAGE_TAG $OPENETHEREUM_IMAGE_REPO
+
+echo Echoing OpenEthereum version:
+docker exec -it $OPENETHEREUM_IMAGE_TAG ./openethereum --version
+
+echo Done.


### PR DESCRIPTION
Adds a shell script for running a detached Docker container of Alpine Linux from openethereum's root directory (similar to that provided for Centos). It shows how the user may then use `docker exec -it eth1.0-openethereum ./openethereum --version` to connect to a bash session in the container to run a openethereum commands.

This is a WIP since I'm still testing it out myself since I need to run a separate Eth1.0 node for my Eth2.0 validator node to sync with in this example https://github.com/ethereum/eth2.0-deposit-cli/pull/83