### PR TITLE
Send RLPx auth in EIP-8 format

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 _Before filing a new issue, please **provide the following information**._
 
-- **OpenEthereum version**: 0.0.0
+- **OpenEthereum version (>=3.1.0)**: 0.0.0
 - **Operating system**: Windows / MacOS / Linux
 - **Installation**: homebrew / one-line installer / built from source
 - **Fully synchronized**: no / yes

--- a/util/network-devp2p/src/handshake.rs
+++ b/util/network-devp2p/src/handshake.rs
@@ -28,7 +28,7 @@ use node_table::NodeId;
 use parity_bytes::Bytes;
 use rand::{random, Rng};
 use rlp::{Rlp, RlpStream};
-use std::{iter::repeat_with, time::Duration};
+use std::{iter::repeat, time::Duration};
 
 #[derive(PartialEq, Eq, Debug)]
 enum HandshakeState {
@@ -321,7 +321,7 @@ impl Handshake {
         let encoded = rlp
             .out()
             .into_iter()
-            .chain(repeat_with(rand::random).take(rand::thread_rng().gen_range::<usize>(100, 301)))
+            .chain(repeat(0).take(rand::thread_rng().gen_range::<usize>(100, 301)))
             .collect::<Vec<_>>();
         let len = (encoded.len() + ECIES_OVERHEAD) as u16;
         let prefix = len.to_be_bytes();

--- a/util/network-devp2p/src/handshake.rs
+++ b/util/network-devp2p/src/handshake.rs
@@ -318,11 +318,11 @@ impl Handshake {
         rlp.append(&self.nonce);
         rlp.append(&PROTOCOL_VERSION);
 
-        let encoded = rlp
-            .out()
-            .into_iter()
-            .chain(repeat(0).take(rand::thread_rng().gen_range::<usize>(100, 301)))
-            .collect::<Vec<_>>();
+        let mut encoded = rlp.out();
+        encoded.resize(
+            encoded.len() + rand::thread_rng().gen_range::<usize>(100, 301),
+            0,
+        );
         let len = (encoded.len() + ECIES_OVERHEAD) as u16;
         let prefix = len.to_be_bytes();
         let message = ecies::encrypt(&self.id, &prefix, &encoded)?;


### PR DESCRIPTION
[EIP-8 specified a new handshake format for RLPx back in 2015.](https://eips.ethereum.org/EIPS/eip-8) It is far more extendable and computationally lighter on the nodes and used throughout all major clients today.

The new handshake format is also supported by OpenEthereum when another node initiates the connection. Unfortunately, however, OpenEthereum itself connects using the old handshake, most likely to support `parity` versions released prior to 2017.

I don't think this is relevant anymore. This PR upgrades outbound handshake to comply with EIP-8 as well. This is important because as I am building [rust-devp2p](https://github.com/rust-ethereum/devp2p) I have to either support two handshake formats (which requires extra maintenance and is more computationally intensive), or drop OpenEthereum to rust-devp2p connectivity. More than that, OE is the last blocker to *all* clients dropping pre-EIP-8 handshake support.