### PR TITLE
Fix deprecated set-env declaration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 env:
   AWS_REGION:                   "us-east-1"
   AWS_S3_ARTIFACTS_BUCKET:      "openethereum-releases"
-      
+
 jobs:
   build:
     name:                       Build Release
@@ -133,7 +133,7 @@ jobs:
     runs-on:                    ubuntu-16.04
     steps:
       - name:                   Set env
-        run:                    echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+        run:                    echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       # ==============================
       #       Create ZIP files
@@ -254,7 +254,7 @@ jobs:
     runs-on:                    ubuntu-16.04
     steps:
       - name:                   Set env
-        run:                    echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+        run:                    echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       # ==============================
       #       Download artifacts

--- a/scripts/actions/install-sccache.ps1
+++ b/scripts/actions/install-sccache.ps1
@@ -15,5 +15,5 @@ curl -LO $url
 tar -xzvf "$basename.tar.gz"
 ls $basename/
 . $basename/sccache --start-server
-echo "::add-path::$(pwd)/$basename"
-echo "::set-env name=RUSTC_WRAPPER::sccache"
+echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV


### PR DESCRIPTION
This PR replaces the old and now deprecated way to set environment variables on the CI.

For further information:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/