### PR TITLE
Add ws-max-paxload

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,35 +33,35 @@ jobs:
           profile:              minimal
           override:             true
       - name:                   Cache cargo registry
-        uses:                   actions/cache@v2
+        uses:                   actions/cache@v1.1.2
         with:
           path:                 ~/.cargo/registry
           key:                  ${{ runner.os }}-cargo-registry-build-tests-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache cargo index
-        uses:                   actions/cache@v2
+        uses:                   actions/cache@v1.1.2
         with:
           path:                 ~/.cargo/git
           key:                  ${{ runner.os }}-cargo-git-build-tests-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache cargo build
-        uses:                   actions/cache@v2
+        uses:                   actions/cache@v1.1.2
         with:
           path:                 target
           key:                  ${{ runner.os }}-cargo-build-target-build-tests-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache sccache linux
         if:                     matrix.platform == 'ubuntu-16.04'
-        uses:                   actions/cache@v2
+        uses:                   actions/cache@v1.1.2
         with:
           path:                 "/home/runner/.cache/sccache"
           key:                  ${{ runner.os }}-sccache-build-tests-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache sccache MacOS
         if:                     matrix.platform == 'macos-latest'
-        uses:                   actions/cache@v2
+        uses:                   actions/cache@v1.1.2
         with:
           path:                 "/Users/runner/Library/Caches/Mozilla.sccache"
           key:                  ${{ runner.os }}-sccache-build-tests-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache sccache Windows
         if:                     matrix.platform == 'windows-latest'
-        uses:                   actions/cache@v2
+        uses:                   actions/cache@v1.1.2
         with:
           path:                 "C:\\Users\\runneradmin\\AppData\\Local\\Mozilla\\sccache\\cache"
           key:                  ${{ runner.os }}-sccache-build-tests-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - stable
 jobs:
   build-tests:
@@ -23,7 +23,7 @@ jobs:
     runs-on:                    ${{ matrix.platform }}
     steps:
       - name:                   Checkout sources
-        uses:                   actions/checkout@master
+        uses:                   actions/checkout@main
         with:
           submodules:           true
       - name:                   Install toolchain

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - ubuntu-20.04
+          - ubuntu-16.04
           - macos-latest
           - windows-latest
         toolchain:
@@ -48,7 +48,7 @@ jobs:
           path:                 target
           key:                  ${{ runner.os }}-cargo-build-target-build-tests-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache sccache linux
-        if:                     matrix.platform == 'ubuntu-20.04'
+        if:                     matrix.platform == 'ubuntu-16.04'
         uses:                   actions/cache@v2
         with:
           path:                 "/home/runner/.cache/sccache"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on:                    ${{ matrix.platform }}
     steps:
       - name:                   Checkout sources
-        uses:                   actions/checkout@master
+        uses:                   actions/checkout@main
       - name:                   Install toolchain
         uses:                   actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - v*
 
+# Global vars
+env:
+  AWS_REGION:                   "us-east-1"
+
 jobs:
   build:
     name:                       Build Release
@@ -14,7 +18,6 @@ jobs:
       SCCACHE_CACHE_SIZE:       "1G"
       SCCACHE_IDLE_TIMEOUT:     0
       AWS_S3_ARTIFACTS_BUCKET:  "openethereum-releases"
-      AWS_REGION:               "us-east-1"
     strategy:
       matrix:
         platform:
@@ -237,7 +240,7 @@ jobs:
         run: |
           # Deploy zip artifacts to S3 bucket to a directory whose name is the tagged release version.
           # Deploy macos binary artifact (if required, add more `aws s3 cp` commands to deploy specific OS versions)
-          aws s3 cp macos-artifacts/openethereum s3://${{ env.AWS_S3_ARTIFACTS_BUCKET }}/${{ env.RELEASE_VERSION }}/macos/
+          aws s3 cp macos-artifacts/openethereum s3://${{ env.AWS_S3_ARTIFACTS_BUCKET }}/${{ env.RELEASE_VERSION }}/macos/ --region ${{ env.AWS_REGION }}
 
     outputs:
       linux-artifact:           ${{ steps.create_zip_linux.outputs.LINUX_ARTIFACT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 # Global vars
 env:
   AWS_REGION:                   "us-east-1"
+  AWS_S3_ARTIFACTS_BUCKET:      "openethereum-releases"
 
 jobs:
   build:
@@ -17,7 +18,6 @@ jobs:
     env:
       SCCACHE_CACHE_SIZE:       "1G"
       SCCACHE_IDLE_TIMEOUT:     0
-      AWS_S3_ARTIFACTS_BUCKET:  "openethereum-releases"
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 env:
   AWS_REGION:                   "us-east-1"
   AWS_S3_ARTIFACTS_BUCKET:      "openethereum-releases"
-
+      
 jobs:
   build:
     name:                       Build Release
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - ubuntu-20.04
+          - ubuntu-16.04
           - macos-latest
           - windows-latest
         toolchain:
@@ -52,7 +52,7 @@ jobs:
           path:                 target
           key:                  ${{ runner.os }}-cargo-build-target-build-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache sccache linux
-        if:                     matrix.platform == 'ubuntu-20.04'
+        if:                     matrix.platform == 'ubuntu-16.04'
         uses:                   actions/cache@v2
         with:
           path:                 "/home/runner/.cache/sccache"
@@ -105,7 +105,7 @@ jobs:
 
       - name:                   Upload Linux build
         uses:                   actions/upload-artifact@v2
-        if:                     matrix.platform == 'ubuntu-20.04'
+        if:                     matrix.platform == 'ubuntu-16.04'
         with:
           name:                 linux-artifacts
           path:                 artifacts
@@ -132,7 +132,7 @@ jobs:
   zip-artifacts-creator:
     name:                       Create zip artifacts
     needs:                      build
-    runs-on:                    ubuntu-20.04
+    runs-on:                    ubuntu-16.04
     steps:
       - name:                   Set env
         run:                    echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
@@ -253,7 +253,7 @@ jobs:
   draft-release:
     name:                       Draft Release
     needs:                      zip-artifacts-creator
-    runs-on:                    ubuntu-20.04
+    runs-on:                    ubuntu-16.04
     steps:
       - name:                   Set env
         run:                    echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - stable
 jobs:
   check:
@@ -15,7 +15,7 @@ jobs:
       SCCACHE_IDLE_TIMEOUT:     0    
     steps:
       - name:                   Checkout sources
-        uses:                   actions/checkout@master
+        uses:                   actions/checkout@main
         with:
           submodules:           true
       - name:                   Install stable toolchain

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     name:                       Check
-    runs-on:                    ubuntu-20.04
+    runs-on:                    ubuntu-16.04
     env:
       SCCACHE_CACHE_SIZE:       "1G"
       SCCACHE_IDLE_TIMEOUT:     0    

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,0 +1,30 @@
+name:                           Docker Image Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  deploy-docker:
+    name:                       Build Release
+    runs-on:                    ubuntu-latest
+    steps:
+      - name:                   Checkout sources
+        uses:                   actions/checkout@master
+      - name:                   Install toolchain
+        uses:                   actions-rs/toolchain@v1
+        with:
+          toolchain:            stable
+          profile:              minimal
+          override:             true
+      - name:                   Deploy to docker hub
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: openethereum/openethereum
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: scripts/docker/alpine/Dockerfile
+          tag_names: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,7 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openethereum"
-version = "3.1.0-rc1"
+version = "3.1.0"
 dependencies = [
  "ansi_term 0.10.2",
  "atty",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "3.1.0-rc1"
+version = "3.1.0"
 dependencies = [
  "parity-bytes",
  "rlp 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "OpenEthereum"
 name = "openethereum"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "3.1.0-rc1"
+version = "3.1.0"
 license = "GPL-3.0"
 authors = [
 	"OpenEthereum developers",

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -466,6 +466,10 @@ usage! {
             "--ws-max-connections=[CONN]",
             "Maximum number of allowed concurrent WebSockets JSON-RPC connections.",
 
+            ARG arg_ws_max_payload: (usize) = 5usize, or |c: &Config| c.websockets.as_ref()?.max_payload,
+            "--ws-max-payload=[MB]",
+            "Specify maximum size for WS JSON-RPC requests in megabytes.",
+
         ["Metrics"]
             FLAG flag_metrics: (bool) = false, or |c: &Config| c.metrics.as_ref()?.enable.clone(),
             "--metrics",
@@ -903,6 +907,7 @@ struct Ws {
     origins: Option<Vec<String>>,
     hosts: Option<Vec<String>>,
     max_connections: Option<usize>,
+    max_payload: Option<usize>,
 }
 
 #[derive(Default, Debug, PartialEq, Deserialize)]
@@ -1323,6 +1328,7 @@ mod tests {
                 arg_ws_origins: "none".into(),
                 arg_ws_hosts: "none".into(),
                 arg_ws_max_connections: 100,
+                arg_ws_max_payload: 5,
 
                 // IPC
                 flag_no_ipc: false,
@@ -1512,6 +1518,7 @@ mod tests {
                     origins: Some(vec!["none".into()]),
                     hosts: None,
                     max_connections: None,
+                    max_payloads: None,
                 }),
                 rpc: Some(Rpc {
                     disable: Some(true),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -951,6 +951,7 @@ impl Configuration {
             signer_path: self.directories().signer.into(),
             support_token_api,
             max_connections: self.args.arg_ws_max_connections,
+            max_payload: self.args.arg_ws_max_payload,
         };
 
         Ok(conf)

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -97,6 +97,7 @@ pub struct WsConfiguration {
     pub hosts: Option<Vec<String>>,
     pub signer_path: PathBuf,
     pub support_token_api: bool,
+    pub max_payload: usize,
 }
 
 impl Default for WsConfiguration {
@@ -116,6 +117,7 @@ impl Default for WsConfiguration {
             hosts: Some(Vec::new()),
             signer_path: replace_home(&data_dir, "$BASE/signer").into(),
             support_token_api: true,
+            max_payload: 5,
         }
     }
 }
@@ -194,6 +196,7 @@ pub fn new_ws<D: rpc_apis::Dependencies>(
         rpc::WsExtractor::new(path.clone()),
         rpc::WsExtractor::new(path.clone()),
         rpc::WsStats::new(deps.stats.clone()),
+        conf.max_payload,
     );
 
     //	match start_result {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -223,6 +223,7 @@ pub fn start_ws<M, S, H, T, U, V>(
     extractor: T,
     middleware: V,
     stats: U,
+    max_payload: usize,
 ) -> Result<ws::Server, ws::Error>
 where
     M: jsonrpc_core::Metadata,
@@ -237,6 +238,7 @@ where
         .allowed_origins(allowed_origins)
         .allowed_hosts(allowed_hosts)
         .max_connections(max_connections)
+        .max_payload(max_payload * 1024 * 1024)
         .session_stats(stats)
         .start(addr)
 }

--- a/rpc/src/tests/ws.rs
+++ b/rpc/src/tests/ws.rs
@@ -44,6 +44,7 @@ pub fn serve() -> (Server<ws::Server>, usize, GuardedAuthCodes) {
             extractors::WsExtractor::new(Some(&authcodes.path)),
             extractors::WsExtractor::new(Some(&authcodes.path)),
             extractors::WsStats::new(stats),
+            5 * 1024 * 1024,
         )
         .unwrap()
     });

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for OpenEthereum version string (via env CARGO_PKG_VERSION)
-version = "3.1.0-rc1"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
I made an issue #85 with patch attached. I've since learned that the proper github way would be to create a pull request. 

This adds an option to set `max-payload` for WS server. By setting a large enough `max-payload,` we can avoid errors with requests larger than the default 5MB:

`WS Error <Io(Custom { kind: InvalidInput, error: "Exceeded maximum buffer capacity" })>`

