### PR TITLE
fix: remove experimental from eth_getProof

### DIFF
--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -680,11 +680,6 @@ where
         values: Vec<H256>,
         num: Option<BlockNumber>,
     ) -> BoxFuture<EthAccount> {
-        try_bf!(errors::require_experimental(
-            self.options.allow_experimental_rpcs,
-            "1186"
-        ));
-
         let key1 = keccak(address);
 
         let num = num.unwrap_or_default();


### PR DESCRIPTION
Since Geth and Nethermind do not have the experimental flag for this, and given that the EIP has had no change for a while, should we remove this API call from being experimental?

Ref:
- https://github.com/ethereum/EIPs/issues/1186
- https://github.com/NethermindEth/nethermind/search?q=experimental
- https://github.com/ethereum/go-ethereum/search?q=experimental