### PR TITLE
Update linked-hash-map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "local-encoding"


### PR DESCRIPTION
The current `dev` branch fails to run after compiling it with rustc `1.48`, digging into the problem I found that the problem was using `memory::uninitialized()` in `linked-hash-map 0.5.2` crate that is used by the `lru-cache` crate.  

The `linked-hash-map 0.5.3` makes the compiled binary with `1.48` working ok and fixes #120