### PR TITLE
Remove gitaction cache

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,38 +32,6 @@ jobs:
           toolchain:            ${{ matrix.toolchain }}
           profile:              minimal
           override:             true
-      - name:                   Cache cargo registry
-        uses:                   actions/cache@v1.1.2
-        with:
-          path:                 ~/.cargo/registry
-          key:                  ${{ runner.os }}-cargo-registry-build-tests-${{ hashFiles('**/Cargo.lock') }}
-      - name:                   Cache cargo index
-        uses:                   actions/cache@v1.1.2
-        with:
-          path:                 ~/.cargo/git
-          key:                  ${{ runner.os }}-cargo-git-build-tests-${{ hashFiles('**/Cargo.lock') }}
-      - name:                   Cache cargo build
-        uses:                   actions/cache@v1.1.2
-        with:
-          path:                 target
-          key:                  ${{ runner.os }}-cargo-build-target-build-tests-${{ hashFiles('**/Cargo.lock') }}
-      - name:                   Cache sccache linux
-        if:                     matrix.platform == 'ubuntu-16.04'
-        uses:                   actions/cache@v1.1.2
-        with:
-          path:                 "/home/runner/.cache/sccache"
-          key:                  ${{ runner.os }}-sccache-build-tests-${{ hashFiles('**/Cargo.lock') }}
-      - name:                   Cache sccache MacOS
-        if:                     matrix.platform == 'macos-latest'
-        uses:                   actions/cache@v1.1.2
-        with:
-          path:                 "/Users/runner/Library/Caches/Mozilla.sccache"
-          key:                  ${{ runner.os }}-sccache-build-tests-${{ hashFiles('**/Cargo.lock') }}
-      - name:                   Install sccache for ${{ matrix.platform }}
-        shell:                  pwsh
-        run:                    pwsh scripts/actions/install-sccache.ps1 ${{ runner.os}}
-      - name:                   Sccache statistics
-        run:                    sccache --show-stats
       - name:                   Build tests
         uses:                   actions-rs/cargo@v1
         with:
@@ -75,9 +43,3 @@ jobs:
         with:
           command:              test
           args:                 --locked --all --release --features "json-tests" --verbose
-      - name:                   Stop sccache
-        if:                     always()
-        run:                    sccache --stop-server
-      - name:                   Prepare build directory for cache
-        shell: bash
-        run:                    bash scripts/actions/clean-target.sh


### PR DESCRIPTION
It happened again that the build fails because of gitaction cache, I think it is best to just disable it and run tests without it.