### PR TITLE
Cleanup devp2p unused interface fn

### DIFF
--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -15,7 +15,12 @@
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use bytes::Bytes;
+
+#[cfg(not(test))]
 use devp2p::PAYLOAD_SOFT_LIMIT;
+#[cfg(test)]
+pub const PAYLOAD_SOFT_LIMIT: usize = 100_000;
+
 use enum_primitive::FromPrimitive;
 use ethereum_types::H256;
 use network::{self, PeerId};

--- a/ethcore/sync/src/chain/supplier.rs
+++ b/ethcore/sync/src/chain/supplier.rs
@@ -15,10 +15,10 @@
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use bytes::Bytes;
+use devp2p::PAYLOAD_SOFT_LIMIT;
 use enum_primitive::FromPrimitive;
 use ethereum_types::H256;
 use network::{self, PeerId};
-use devp2p::PAYLOAD_SOFT_LIMIT;
 use parking_lot::RwLock;
 use rlp::{Rlp, RlpStream};
 use std::cmp;

--- a/ethcore/sync/src/sync_io.rs
+++ b/ethcore/sync/src/sync_io.rs
@@ -46,8 +46,6 @@ pub trait SyncIo {
     }
     /// Returns information on p2p session
     fn peer_session_info(&self, peer_id: PeerId) -> Option<SessionInfo>;
-    /// Maximum mutually supported ETH protocol version
-    fn eth_protocol_version(&self, peer_id: PeerId) -> u8;
     /// Maximum mutually supported version of a gien protocol.
     fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8;
     /// Returns if the chain block queue empty
@@ -58,8 +56,6 @@ pub trait SyncIo {
     fn is_expired(&self) -> bool;
     /// Return sync overlay
     fn chain_overlay(&self) -> &RwLock<HashMap<BlockNumber, Bytes>>;
-    /// Returns the size the payload shouldn't exceed
-    fn payload_soft_limit(&self) -> usize;
 }
 
 /// Wraps `NetworkContext` and the blockchain client
@@ -125,12 +121,6 @@ impl<'s> SyncIo for NetSyncIo<'s> {
         self.network.is_expired()
     }
 
-    fn eth_protocol_version(&self, peer_id: PeerId) -> u8 {
-        self.network
-            .protocol_version(self.network.subprotocol_name(), peer_id)
-            .unwrap_or(0)
-    }
-
     fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8 {
         self.network
             .protocol_version(*protocol, peer_id)
@@ -139,9 +129,5 @@ impl<'s> SyncIo for NetSyncIo<'s> {
 
     fn peer_version(&self, peer_id: PeerId) -> ClientVersion {
         self.network.peer_client_version(peer_id)
-    }
-
-    fn payload_soft_limit(&self) -> usize {
-        self.network.payload_soft_limit()
     }
 }

--- a/ethcore/sync/src/tests/helpers.rs
+++ b/ethcore/sync/src/tests/helpers.rs
@@ -168,24 +168,16 @@ where
         None
     }
 
-    fn eth_protocol_version(&self, _peer: PeerId) -> u8 {
-        ETH_PROTOCOL_VERSION_64.0
-    }
-
     fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8 {
         if protocol == &PAR_PROTOCOL {
             PAR_PROTOCOL_VERSION_2.0
         } else {
-            self.eth_protocol_version(peer_id)
+            ETH_PROTOCOL_VERSION_64.0
         }
     }
 
     fn chain_overlay(&self) -> &RwLock<HashMap<BlockNumber, Bytes>> {
         &self.overlay
-    }
-
-    fn payload_soft_limit(&self) -> usize {
-        100_000
     }
 }
 

--- a/ethcore/sync/src/tests/helpers.rs
+++ b/ethcore/sync/src/tests/helpers.rs
@@ -168,7 +168,7 @@ where
         None
     }
 
-    fn protocol_version(&self, protocol: &ProtocolId, peer_id: PeerId) -> u8 {
+    fn protocol_version(&self, protocol: &ProtocolId, _peer_id: PeerId) -> u8 {
         if protocol == &PAR_PROTOCOL {
             PAR_PROTOCOL_VERSION_2.0
         } else {

--- a/util/network-devp2p/src/connection.rs
+++ b/util/network-devp2p/src/connection.rs
@@ -44,7 +44,10 @@ pub const MAX_PAYLOAD_SIZE: usize = (1 << 24) - 1;
 
 /// Network responses should try not to go over this limit.
 /// This should be lower than MAX_PAYLOAD_SIZE
+#[cfg(not(test))]
 pub const PAYLOAD_SOFT_LIMIT: usize = (1 << 22) - 1;
+#[cfg(test)]
+pub const PAYLOAD_SOFT_LIMIT: usize = 100_000;
 
 pub trait GenericSocket: Read + Write {}
 

--- a/util/network-devp2p/src/connection.rs
+++ b/util/network-devp2p/src/connection.rs
@@ -44,10 +44,7 @@ pub const MAX_PAYLOAD_SIZE: usize = (1 << 24) - 1;
 
 /// Network responses should try not to go over this limit.
 /// This should be lower than MAX_PAYLOAD_SIZE
-#[cfg(not(test))]
 pub const PAYLOAD_SOFT_LIMIT: usize = (1 << 22) - 1;
-#[cfg(test)]
-pub const PAYLOAD_SOFT_LIMIT: usize = 100_000;
 
 pub trait GenericSocket: Read + Write {}
 

--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -35,7 +35,6 @@ use std::{
     time::Duration,
 };
 
-use connection::PAYLOAD_SOFT_LIMIT;
 use discovery::{Discovery, NodeEntry, TableUpdates, MAX_DATAGRAM_SIZE};
 use io::*;
 use ip_utils::{map_external_address, select_public_address};
@@ -225,10 +224,6 @@ impl<'s> NetworkContextTrait for NetworkContext<'s> {
             .and_then(|info| info.id)
             .map(|node| self.reserved_peers.contains(&node))
             .unwrap_or(false)
-    }
-
-    fn payload_soft_limit(&self) -> usize {
-        PAYLOAD_SOFT_LIMIT
     }
 }
 

--- a/util/network-devp2p/src/lib.rs
+++ b/util/network-devp2p/src/lib.rs
@@ -113,6 +113,8 @@ mod session;
 pub use host::NetworkContext;
 pub use service::NetworkService;
 
+pub use connection::PAYLOAD_SOFT_LIMIT;
+
 pub use io::TimerToken;
 pub use node_table::{validate_node_url, NodeId};
 

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -320,9 +320,6 @@ pub trait NetworkContext {
 
     /// Returns whether the given peer ID is a reserved peer.
     fn is_reserved_peer(&self, peer: PeerId) -> bool;
-
-    /// Returns the size the payload shouldn't exceed
-    fn payload_soft_limit(&self) -> usize;
 }
 
 impl<'a, T> NetworkContext for &'a T
@@ -381,10 +378,6 @@ where
 
     fn is_reserved_peer(&self, peer: PeerId) -> bool {
         (**self).is_reserved_peer(peer)
-    }
-
-    fn payload_soft_limit(&self) -> usize {
-        (**self).payload_soft_limit()
     }
 }
 


### PR DESCRIPTION
Cleanup change:
Removing unused `fn eth_protocol_version`
Replacing `fn payload_soft_limit` with `PAYLOAD_SOFT_LIMIT` constant.