### PR TITLE
Actualize spec files for POA Networks

### DIFF
--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -88,9 +88,13 @@
 			"builtin": {
 				"name": "ecrecover",
 				"pricing": {
-					"linear": {
-						"base": 3000,
-						"word": 0
+					"0": {
+						"price": {
+							"linear": {
+								"base": 3000,
+								"word": 0
+							}
+						}
 					}
 				}
 			}
@@ -100,9 +104,13 @@
 			"builtin": {
 				"name": "sha256",
 				"pricing": {
-					"linear": {
-						"base": 60,
-						"word": 12
+					"0": {
+						"price": {
+							"linear": {
+								"base": 60,
+								"word": 12
+							}
+						}
 					}
 				}
 			}
@@ -112,9 +120,13 @@
 			"builtin": {
 				"name": "ripemd160",
 				"pricing": {
-					"linear": {
-						"base": 600,
-						"word": 120
+					"0": {
+						"price": {
+							"linear": {
+								"base": 600,
+								"word": 120
+							}
+						}
 					}
 				}
 			}
@@ -124,9 +136,13 @@
 			"builtin": {
 				"name": "identity",
 				"pricing": {
-					"linear": {
-						"base": 15,
-						"word": 3
+					"0": {
+						"price": {
+							"linear": {
+								"base": 15,
+								"word": 3
+							}
+						}
 					}
 				}
 			}
@@ -134,10 +150,13 @@
 		"0x0000000000000000000000000000000000000005": {
 			"builtin": {
 				"name": "modexp",
-				"activate_at": "0x4d50f8",
 				"pricing": {
-					"modexp": {
-						"divisor": 20
+					"0x4d50f8": {
+						"price": {
+							"modexp": {
+								"divisor": 20
+							}
+						}
 					}
 				}
 			}
@@ -147,11 +166,19 @@
 				"name": "alt_bn128_add",
 				"pricing": {
 					"0x4d50f8": {
-						"price": { "alt_bn128_const_operations": { "price": 500 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 500
+							}
+						}
 					},
 					"0xd751a5": {
 						"info": "EIP 1108 transition at block 14_111_141 (0xd751a5)",
-						"price": { "alt_bn128_const_operations": { "price": 150 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 150
+							}
+						}
 					}
 				}
 			}
@@ -161,11 +188,19 @@
 				"name": "alt_bn128_mul",
 				"pricing": {
 					"0x4d50f8": {
-						"price": { "alt_bn128_const_operations": { "price": 40000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 40000
+							}
+						}
 					},
 					"0xd751a5": {
 						"info": "EIP 1108 transition at block 14_111_141 (0xd751a5)",
-						"price": { "alt_bn128_const_operations": { "price": 6000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 6000
+							}
+						}
 					}
 				}
 			}
@@ -175,11 +210,21 @@
 				"name": "alt_bn128_pairing",
 				"pricing": {
 					"0x4d50f8": {
-						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 100000,
+								"pair": 80000
+							}
+						}
 					},
 					"0xd751a5": {
 						"info": "EIP 1108 transition at block 14_111_141 (0xd751a5)",
-						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 45000,
+								"pair": 34000
+							}
+						}
 					}
 				}
 			}
@@ -187,10 +232,13 @@
 		"0x0000000000000000000000000000000000000009": {
 			"builtin": {
 				"name": "blake2_f",
-				"activate_at": "0xd751a5",
 				"pricing": {
-					"blake2_f": {
-						"gas_per_round": 1
+					"0xd751a5": {
+						"price": {
+							"blake2_f": {
+								"gas_per_round": 1
+							}
+						}
 					}
 				}
 			}
@@ -200,13 +248,9 @@
 		}
 	},
 	"nodes": [
-		"enode://f6e37b943bad3a78cb8589b1798d30d210ffd39cfcd2c8f2de4f098467fd49c667980100d919da7ca46cd50505d30989abda87f0b9339377de13d6592c22caf8@34.198.49.72:30303",
 		"enode://16898006ba2cd4fa8bf9a3dfe32684c178fa861df144bfc21fe800dc4838a03e342056951fa9fd533dcb0be1219e306106442ff2cf1f7e9f8faa5f2fc1a3aa45@116.203.116.241:30303",
 		"enode://2909846f78c37510cc0e306f185323b83bb2209e5ff4fdd279d93c60e3f365e3c6e62ad1d2133ff11f9fd6d23ad9c3dad73bb974d53a22f7d1ac5b7dea79d0b0@3.217.96.11:30303",
-		"enode://56abaf065581a5985b8c5f4f88bd202526482761ba10be9bfdcd14846dd01f652ec33fde0f8c0fd1db19b59a4c04465681fcef50e11380ca88d25996191c52de@40.71.221.215:30303",
-		"enode://d07827483dc47b368eaf88454fb04b41b7452cf454e194e2bd4c14f98a3278fed5d819dbecd0d010407fc7688d941ee1e58d4f9c6354d3da3be92f55c17d7ce3@52.166.117.77:30303",
-		"enode://38e6e7fd416293ed120d567a2675fe078c0205ab0671abf16982ce969823bd1f3443d590c18b321dfae7dcbe1f6ba98ef8702f255c3c9822a188abb82c53adca@51.77.66.187:30303",
-		"enode://6f289111f7c77c68651b0f4803c3a47bcec801f9c618bb41231a1a24a6dbb9c76f2fdb63ba7a21357c41ebb7f6922c17397c1b5c8f71f7d3ef7965505d4945de@144.217.72.209:30303",
-		"enode://b6340eb94c3db1362ee517801389fe21cce6354275376b1006f8ce84f8a5cfa2b836268b3727be9db7cd3e581f356f39da39418c4ec1d63d959abc235d99cd86@145.239.7.213:30303"
+		"enode://740e1c8ea64e71762c71a463a04e2046070a0c9394fcab5891d41301dc473c0cff00ebab5a9bc87fbcb610ab98ac18225ff897bc8b7b38def5975d5ceb0a7d7c@108.61.170.124:30303",
+		"enode://2909846f78c37510cc0e306f185323b83bb2209e5ff4fdd279d93c60e3f365e3c6e62ad1d2133ff11f9fd6d23ad9c3dad73bb974d53a22f7d1ac5b7dea79d0b0@157.230.31.163:30303"
 	]
 }

--- a/ethcore/res/ethereum/poacore.json
+++ b/ethcore/res/ethereum/poacore.json
@@ -22,7 +22,10 @@
 					}
 				},
 				"blockRewardContractAddress": "0x4d0153D434384128D17243409e02fca1B3EE21D6",
-				"blockRewardContractTransition": 5761140
+				"blockRewardContractTransition": 5761140,
+				"randomnessContractAddress": {
+					"14350721": "0x67e90a54AeEA85f21949c645082FE95d77BC1E70"
+				}
 			}
 		}
 	},
@@ -55,12 +58,12 @@
 		"gasLimit": "0x663BE0"
 	},
 	"nodes": [
+		"enode://b39c9c438c533ff7aed6aaefb1c116a350ee3acc3f37c2d6cb85d2a949296238174fe1cb9a04d6a1204b38ca12f63fe4827eaa860fd889a898735fbaba4cca58@178.128.175.244:30303",
+		"enode://24f3bf1307b8e9cd53abaaa339db5653aa3db64d579f7f37788b8a9b938420cc10004dc9af4edbb0f0611a57b741a4912dd081917b3d373e4409d788c422e7e6@134.209.22.144:30303",
+		"enode://b39c9c438c533ff7aed6aaefb1c116a350ee3acc3f37c2d6cb85d2a949296238174fe1cb9a04d6a1204b38ca12f63fe4827eaa860fd889a898735fbaba4cca58@142.93.3.70:30303",
 		"enode://6e3d1b39cbd2a9c4f053a27e68fd90d0bac83691dfdc4a13c59f2555078a71e63c5daaee5a82aa6db500512760a5456f86076bf8bbe8011c27c82ed7d6f5fb26@45.77.140.210:30303",
 		"enode://31dffed97f8fed1f34fe66453280a89cbeeda60cf28f6fbb212ebbefd7c7566a02c1c7d5c00bbbb49b9fa8a49f157e0f786f379ca9bcbf2fea24de70d70a22b6@206.156.242.61:30303",
-		"enode://6bdc7553ab2e4914cb47774c1e6d8c8f47ac7c3981891f85f65d06f208ea1bc4d3bf982b330950e0a0cd127efd7145c4df7113159a1d4a06ed722e6c16d0ac6c@45.32.215.190:30303",
-		"enode://872d82a24144bc007658fb6fac0dcdfb9b63aeb05ef563a06d0186f2d1e5ffbfc5c4f1244891a8a86ef70682b9d24382e654b305224883698862e2df647a4d23@45.76.236.247:30303",
-		"enode://b11fbc6cde81c80be69508aca8ffea8460680a25a9c151b683293f8617282062b8e8e139bf91e88cedf60068a3cf927b0d48832fda5169b58a8f7ce442de6fb4@206.189.76.132:30303",
-		"enode://96678da10ac83769ab3f63114a41b57b700476c5ac02719b878fa89909a936551bb7609aa09b068bf89903206fa03f23e1b5b9117ca278de304c2570b87dcb27@35.175.15.164:30303"
+		"enode://b39c9c438c533ff7aed6aaefb1c116a350ee3acc3f37c2d6cb85d2a949296238174fe1cb9a04d6a1204b38ca12f63fe4827eaa860fd889a898735fbaba4cca58@178.128.175.244:30303"
 	],
 	"accounts": {
 		"0x0000000000000000000000000000000000000005": {
@@ -82,11 +85,19 @@
 				"name": "alt_bn128_add",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_const_operations": { "price": 500 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 500
+							}
+						}
 					},
 					"12598600": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_const_operations": { "price": 150 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 150
+							}
+						}
 					}
 				}
 			}
@@ -96,11 +107,19 @@
 				"name": "alt_bn128_mul",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_const_operations": { "price": 40000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 40000
+							}
+						}
 					},
 					"12598600": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_const_operations": { "price": 6000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 6000
+							}
+						}
 					}
 				}
 			}
@@ -110,11 +129,21 @@
 				"name": "alt_bn128_pairing",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 100000,
+								"pair": 80000
+							}
+						}
 					},
 					"12598600": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 45000,
+								"pair": 34000
+							}
+						}
 					}
 				}
 			}

--- a/ethcore/res/ethereum/poasokol.json
+++ b/ethcore/res/ethereum/poasokol.json
@@ -25,7 +25,10 @@
 					}
 				},
 				"blockRewardContractAddress": "0x3145197AD50D7083D0222DE4fCCf67d9BD05C30D",
-				"blockRewardContractTransition": 4639000
+				"blockRewardContractTransition": 4639000,
+				"randomnessContractAddress": {
+					"13391641": "0x8f2b78169B0970F11a762e56659Db52B59CBCf1B"
+				}
 			}
 		}
 	},
@@ -60,14 +63,10 @@
 		"gasLimit": "0x663BE0"
 	},
 	"nodes": [
-		"enode://bdcd6f875583df2bd8094f08ae58c7c2db6ed67795ca8c0e6415a30721d3657291aec9b933d15e17e0b36ad7a76424a1447ddbfc75809a04f7a0ffef5617dd56@3.91.206.172:30303",
-		"enode://8e0af07c86ec36590bb6368e7ad0c45b6dc658f5fb66ec68889a614affddda5e021bd513bcf4fb2fae4a3bbe08cf0de84f037cd58478a89665dfce1ded2595c7@34.236.37.74:30303",
+		"enode://f11a0f80939b49a28bf99581da9b351a592ec1504b9d32a7dfda79b36510a891e96631239c4166e5c73368c21e9bb3241e7fd6929b899772e5a8fe9a7b7c3af6@45.77.52.149:30303",
+		"enode://e08adce358fc26dfbe1f24ee578dceaa29575ca44a39d9041203131db5135aceba6241840a9b57b1540eeaf7b4eff1aead28a74641be43342c35af454abb31b3@199.247.18.10:30313",
 		"enode://f1a5100a81cb73163ae450c584d06b1f644aa4fad4486c6aeb4c384b343c54bb66c744aa5f133af66ea1b25f0f4a454f04878f3e96ee4cd2390c047396d6357b@209.97.158.4:30303",
-		"enode://0d1e0372f63a3f0b82d66635ea101ecc0f6797788a078805cc933dd93e6a22f7c9fa51ab4e2d21da02d04480ef19f3bbb9a2b41dd1c262085d295a354bb8b0f9@18.217.47.209:30303",
-		"enode://875e1bd1b98019a5d6d588c23f68534b75462dd6ecbb3dd058221dbf7aa923f0ab782ab93bb82d42edc9996f7f0816a318bdc761e55c02b95e1169cef66f7edc@159.203.24.35:30303",
-		"enode://8e0af07c86ec36590bb6368e7ad0c45b6dc658f5fb66ec68889a614affddda5e021bd513bcf4fb2fae4a3bbe08cf0de84f037cd58478a89665dfce1ded2595c7@34.236.37.74:30303",
-		"enode://182ee200ca134dc4d6390f3d5aadbcd80df0f7f24335830335d142573eacce4eeb919d30e82c5df588034e167e6ba6dd11187502ac9264a71005127f6b146a99@159.203.95.241:30303",
-		"enode://b022ff70b5fcaf9596ae5efed99a8198b4ae0578ee9d17b733609d803a75cef95d3a2a18e50dca9a7c3b26139f158c59eaf8b5fb8d1d331c9a46934a78acabe8@206.189.76.128:30303"
+		"enode://f11a0f80939b49a28bf99581da9b351a592ec1504b9d32a7dfda79b36510a891e96631239c4166e5c73368c21e9bb3241e7fd6929b899772e5a8fe9a7b7c3af6@45.77.52.149:30303"
 	],
 	"accounts": {
 		"0000000000000000000000000000000000000005": {
@@ -89,11 +88,19 @@
 				"name": "alt_bn128_add",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_const_operations": { "price": 500 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 500
+							}
+						}
 					},
 					"12095200": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_const_operations": { "price": 150 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 150
+							}
+						}
 					}
 				}
 			}
@@ -103,11 +110,19 @@
 				"name": "alt_bn128_mul",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_const_operations": { "price": 40000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 40000
+							}
+						}
 					},
 					"12095200": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_const_operations": { "price": 6000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 6000
+							}
+						}
 					}
 				}
 			}
@@ -117,11 +132,21 @@
 				"name": "alt_bn128_pairing",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 100000,
+								"pair": 80000
+							}
+						}
 					},
 					"12095200": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 45000,
+								"pair": 34000
+							}
+						}
 					}
 				}
 			}

--- a/ethcore/res/ethereum/xdai.json
+++ b/ethcore/res/ethereum/xdai.json
@@ -11,15 +11,27 @@
 				"validators": {
 					"multi": {
 						"0": {
-							"list": ["0xcace5b3c29211740e595850e80478416ee77ca21"]
+							"list": [
+								"0xcace5b3c29211740e595850e80478416ee77ca21"
+							]
 						},
 						"1300": {
 							"safeContract": "0x22e1229a2c5b95a60983b5577f745a603284f535"
+						},
+						"9186425": {
+							"contract": "0xB87BE9f7196F2AE084Ca1DE6af5264292976e013"
 						}
 					}
 				},
 				"blockRewardContractAddress": "0x867305d19606aadba405ce534e303d0e225f9556",
-				"blockRewardContractTransition": 1310
+				"blockRewardContractTransition": 1310,
+				"blockRewardContractTransitions": {
+					"9186425": "0x481c034c6d9441db23Ea48De68BCAe812C5d39bA"
+				},
+				"randomnessContractAddress": {
+					"9186425": "0x5870b0527DeDB1cFBD9534343Feda1a41Ce47766"
+				},
+				"posdaoTransition": 9186425
 			}
 		}
 	},
@@ -42,7 +54,9 @@
 		"eip1706Transition": 7298030,
 		"eip1884Transition": 7298030,
 		"eip2028Transition": 7298030,
-		"registrar": "0x1ec97dc137f5168af053c24460a1200502e1a9d2"
+		"registrar": "0x6B53721D4f2Fb9514B85f5C49b197D857e36Cf03",
+		"transactionPermissionContract": "0x7Dd7032AA75A37ea0b150f57F899119C7379A78b",
+		"transactionPermissionContractTransition": 9186425
 	},
 	"genesis": {
 		"seal": {
@@ -54,6 +68,25 @@
 		"difficulty": "0x20000",
 		"gasLimit": "0x989680"
 	},
+	"nodes": [
+		"enode://4716883567b5317aad93ea28e707fad0631fb4aa5ac7c5fbd485380b01d8801c21a8cbf4d6ee3a2c9b2b070a270a49d4a2a0da9e1d47a1f433dafbaf7b2edd06@157.245.92.222:30303",
+		"enode://ab7f6c633ba2dc54795dfd2c739ba7d964f499541c0b8d8ba9d275bd3df1b789470a21a921a469fa515a3dfccc96a434a3fd016a169d88d0043fc6744f34288e@67.205.180.17:30303",
+		"enode://0caa2d84aef00d0bc5de6cf9db3e736da245d882ec8f91e201b3e1635960e62cbb2f8bfc57e679ff3e1d53da2773e31df624a56b2f457ecb51d09fdf9970c86b@67.205.145.143:30303",
+		"enode://bd75111424c42c349fc255db017ac0be370b37b558627e3bbc41319071ef7642c04cdbd2b674193a99aa35d67a83016ab293b8ab87ed4a4606e69f114ac95535@157.230.185.80:30303",
+		"enode://bd75111424c42c349fc255db017ac0be370b37b558627e3bbc41319071ef7642c04cdbd2b674193a99aa35d67a83016ab293b8ab87ed4a4606e69f114ac95535@161.35.51.60:30303",
+		"enode://ef94ffb10c440dd990c5c4be1c85046f5f7329ba60d23db7a68c8b91b6a721081f8190369f3a32f3c02d213127b2066eb42ee0444998d354ba0923378522acb3@161.35.62.72:30303",
+		"enode://4a0eadf22d6a37c5596fd2df2a53a26a5b59dd863e67246ab94e6a81b31765e08d9f70a4dd9683221e63cc2120c8a808a6a457455bd658bdf49c688c62db2011@51.81.244.170:30303",
+		"enode://e75a1e9f080bd6012b39321c0f2d984567172625280b3e7362e962a42578c5e79c847b3eb83aa7e2a4cdeefbfadf0c36ed2719cad1d5e6377ccd6ebe314cc6bc@64.227.97.130:30303",
+		"enode://6674773f7aac78d5527fa90c847dcbca198de4081306406a8fec5c15f7a2e141362344041291dd10d0aafa7706a3d8f21a08b6f6834a5b1aab9cccd8ca35ccee@143.110.226.15:30303",
+		"enode://0caa2d84aef00d0bc5de6cf9db3e736da245d882ec8f91e201b3e1635960e62cbb2f8bfc57e679ff3e1d53da2773e31df624a56b2f457ecb51d09fdf9970c86b@134.122.24.231:30303",
+		"enode://0caa2d84aef00d0bc5de6cf9db3e736da245d882ec8f91e201b3e1635960e62cbb2f8bfc57e679ff3e1d53da2773e31df624a56b2f457ecb51d09fdf9970c86b@67.205.145.143:30303",
+		"enode://0caa2d84aef00d0bc5de6cf9db3e736da245d882ec8f91e201b3e1635960e62cbb2f8bfc57e679ff3e1d53da2773e31df624a56b2f457ecb51d09fdf9970c86b@162.243.164.98:30303",
+		"enode://0caa2d84aef00d0bc5de6cf9db3e736da245d882ec8f91e201b3e1635960e62cbb2f8bfc57e679ff3e1d53da2773e31df624a56b2f457ecb51d09fdf9970c86b@167.99.4.175:30303",
+		"enode://da2449aaba873c40c6daf764de55f4b9eae24c4738daec893ef95b6ada96463c6b9624f8e376e1073d21dd820c5bb361e14575121b09bbd7735b6b556ee1b768@67.205.176.117:30303",
+		"enode://e8c7a0db430429bb374c981438c0dbd95e565088a483388aa46d8377a3bd62f02cd83d7e2c7e5fc77606141bfef29d23d4285a7c1d9b7e743cf3029314506df7@80.240.16.221:30303",
+		"enode://2cde5ae04ed57bba5bac8311a97be056838d5304bc3bcee698066e5fc532e846f785198f87e8b84b57b03622a22aac5dd2853c5203d1ece2c9f25b48487d145b@149.28.57.8:30303",
+		"enode://90b0a0e74a9a1ad258531b4ceec25587d8b52ff2cfb36206a34bf6ba1a8d21b2abd20da13260102508a2ac67afbeb2d2ab7a5e9d6bea3bce845cd81e655585cc@45.77.110.159:30303"
+	],
 	"accounts": {
 		"0x0000000000000000000000000000000000000005": {
 			"builtin": {
@@ -74,11 +107,19 @@
 				"name": "alt_bn128_add",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_const_operations": { "price": 500 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 500
+							}
+						}
 					},
 					"7298030": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_const_operations": { "price": 150 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 150
+							}
+						}
 					}
 				}
 			}
@@ -88,11 +129,19 @@
 				"name": "alt_bn128_mul",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_const_operations": { "price": 40000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 40000
+							}
+						}
 					},
 					"7298030": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_const_operations": { "price": 6000 }}
+						"price": {
+							"alt_bn128_const_operations": {
+								"price": 6000
+							}
+						}
 					}
 				}
 			}
@@ -102,11 +151,21 @@
 				"name": "alt_bn128_pairing",
 				"pricing": {
 					"0": {
-						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 100000,
+								"pair": 80000
+							}
+						}
 					},
 					"7298030": {
 						"info": "EIP 1108 transition",
-						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
+						"price": {
+							"alt_bn128_pairing": {
+								"base": 45000,
+								"pair": 34000
+							}
+						}
 					}
 				}
 			}
@@ -190,10 +249,6 @@
 				}
 			}
 		}
-	},
-	"nodes": [
-		"enode://1c19ba0a77dd663b843c33beb9020e7eb41fc34b47b98424dbc427f74692115d74c7c27b6c0aa2b59bb1d8f710650cae1090153d10b6909ca7bdcdfb183b1c59@54.39.190.172:30303",
-		"enode://c1c3a604950119f82d78189792b73f5a82a239017c77465e3c32fc51c1d758a9a772ffddd58436d465342f2cfa6d4a442a49e526743f4d8354d7c5ce794c3ee5@95.179.222.48:30303"
-	]
+	}
 }
 


### PR DESCRIPTION
Since for OpenEthereum we have a gap between v2.5.14 and v3.1, we need to update spec files for all POA networks (POA Core, POA Sokol, xDai, Kovan).