### PR TITLE
Set alpine version to 3.12.3

### DIFF
--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge AS builder
+FROM alpine:3.12.3 AS builder
 
 # show backtraces
 ENV RUST_BACKTRACE 1
@@ -18,7 +18,7 @@ COPY . /openethereum
 RUN cargo build --release --features final --target x86_64-alpine-linux-musl --verbose
 RUN strip target/x86_64-alpine-linux-musl/release/openethereum
 
-FROM alpine:edge
+FROM alpine:3.12.3
 
 # show backtraces
 ENV RUST_BACKTRACE 1


### PR DESCRIPTION
Alpine version is changed in order to prevent Cmake errors. Reference: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12321.

Intends to solve https://github.com/openethereum/openethereum/issues/230