### PR TITLE
Yolo3 maximumExtraDataSize

### DIFF
--- a/crates/ethcore/res/chainspec/test/yolo3_test.json
+++ b/crates/ethcore/res/chainspec/test/yolo3_test.json
@@ -35,7 +35,7 @@
 		"gasLimitBoundDivisor": "0x0400",
 		"maxCodeSize": 24576,
 		"maxCodeSizeTransition": "0x0",
-		"maximumExtraDataSize": "0x20",
+		"maximumExtraDataSize": "0xffff",
 		"minGasLimit": "0x1388",
 		"networkID": "133519467574835",
 		"registrar": "0xc6d9d2cd449a754c494264e1809c50e34d64562b"


### PR DESCRIPTION
Clique needs more extradata than ethash. Config value is from Goerli.