### PR TITLE
Give IoService a consistent interface

### DIFF
--- a/crates/runtime/io/src/service_non_mio.rs
+++ b/crates/runtime/io/src/service_non_mio.rs
@@ -267,7 +267,9 @@ where
     Message: Send + Sync + 'static,
 {
     /// Starts IO event loop
-    pub fn start() -> Result<IoService<Message>, IoError> {
+    pub fn start(_symbolic_name: &'static str) -> Result<IoService<Message>, IoError> {
+        // This minimal implementation of IoService does have named Workers
+        // like the mio-dependent one does, so _symbolic_name is ignored.
         let (tx, rx) = deque::fifo();
 
         let shared = Arc::new(Shared {


### PR DESCRIPTION
The start() method had two different signatures depending on configuration. Since ethcore is built with either config depending on the build target, this resulted in compiler errors for either evmbin or oe.