### PR TITLE
Sunce86/add support eip2930 ethereum tests runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,6 @@ name = "common-types"
 version = "0.1.0"
 dependencies = [
  "ethereum-types 0.4.2",
- "ethjson",
  "ethkey",
  "heapsize",
  "keccak-hash",
@@ -1375,7 +1374,9 @@ dependencies = [
 name = "ethjson"
 version = "0.1.0"
 dependencies = [
+ "common-types",
  "ethereum-types 0.4.2",
+ "ethkey",
  "macros",
  "maplit",
  "rustc-hex 1.0.0",

--- a/bin/evmbin/src/main.rs
+++ b/bin/evmbin/src/main.rs
@@ -204,7 +204,7 @@ fn run_state_test(args: Args) {
             }
             for (idx, state) in states.into_iter().enumerate() {
                 let post_root = state.hash.into();
-                let transaction = multitransaction.select(&state.indexes).into();
+                let transaction = multitransaction.select(&state.indexes);
 
                 let trie_spec = if args.flag_std_dump_json {
                     TrieSpec::Fat

--- a/crates/ethcore/src/json_tests/runner.rs
+++ b/crates/ethcore/src/json_tests/runner.rs
@@ -184,7 +184,7 @@ impl TestRunner {
                         return Vec::new();
                     }
                 }
-                super::state::json_chain_test(&test, &path, &json, &mut |_, _| {})
+                super::state::json_state_test(&test, &path, &json, &mut |_, _| {})
             },
         )
     }

--- a/crates/ethcore/src/json_tests/state.rs
+++ b/crates/ethcore/src/json_tests/state.rs
@@ -42,7 +42,7 @@ fn skip_test(
     })
 }
 
-pub fn json_chain_test<H: FnMut(&str, HookType)>(
+pub fn json_state_test<H: FnMut(&str, HookType)>(
     state_test: &ethjson::test::StateTests,
     path: &Path,
     json_data: &[u8],

--- a/crates/ethcore/src/json_tests/state.rs
+++ b/crates/ethcore/src/json_tests/state.rs
@@ -20,7 +20,6 @@ use ethjson;
 use pod_state::PodState;
 use std::path::Path;
 use trace;
-use types::transaction::SignedTransaction;
 use vm::EnvInfo;
 
 fn skip_test(
@@ -91,8 +90,7 @@ pub fn json_state_test<H: FnMut(&str, HookType)>(
                     }
 
                     let post_root: H256 = state.hash.into();
-                    let transaction: SignedTransaction =
-                        multitransaction.select(&state.indexes).into();
+                    let transaction = multitransaction.select(&state.indexes);
 
                     let result = || -> Result<_, EvmTestError> {
                         Ok(EvmTestClient::from_pod_state(&spec, pre.clone())?.transact(

--- a/crates/ethcore/types/Cargo.toml
+++ b/crates/ethcore/types/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 ethereum-types = "0.4"
-ethjson = { path = "../../ethjson" }
 ethkey = { path = "../../accounts/ethkey" }
 heapsize = "0.4"
 keccak-hash = "0.1"

--- a/crates/ethcore/types/src/lib.rs
+++ b/crates/ethcore/types/src/lib.rs
@@ -35,7 +35,6 @@
 #![warn(unused_extern_crates)]
 
 extern crate ethereum_types;
-extern crate ethjson;
 extern crate ethkey;
 extern crate heapsize;
 extern crate keccak_hash as hash;

--- a/crates/ethcore/types/src/log_entry.rs
+++ b/crates/ethcore/types/src/log_entry.rs
@@ -21,7 +21,6 @@ use ethereum_types::{Address, Bloom, BloomInput, H256};
 use heapsize::HeapSizeOf;
 use std::ops::Deref;
 
-use ethjson;
 use BlockNumber;
 
 /// A record of execution for a `LOG` operation.
@@ -50,16 +49,6 @@ impl LogEntry {
                 b.accrue(BloomInput::Raw(t));
                 b
             })
-    }
-}
-
-impl From<ethjson::state::Log> for LogEntry {
-    fn from(l: ethjson::state::Log) -> Self {
-        LogEntry {
-            address: l.address.into(),
-            topics: l.topics.into_iter().map(Into::into).collect(),
-            data: l.data.into(),
-        }
     }
 }
 

--- a/crates/ethcore/types/src/transaction/transaction.rs
+++ b/crates/ethcore/types/src/transaction/transaction.rs
@@ -628,7 +628,7 @@ impl From<ethjson::state::transaction::TypedTransaction> for SignedTransaction {
     fn from(t: ethjson::state::transaction::TypedTransaction) -> Self {
         match t {
             ethjson::state::transaction::TypedTransaction::AccessList(tx) => tx.into(),
-            ethjson::state::transaction::TypedTransaction::Legacy(tx) => tx.into()
+            ethjson::state::transaction::TypedTransaction::Legacy(tx) => tx.into(),
         }
     }
 }
@@ -650,18 +650,22 @@ impl From<ethjson::state::Transaction> for SignedTransaction {
 impl From<ethjson::state::transaction::AccessListTx> for SignedTransaction {
     fn from(t: ethjson::state::transaction::AccessListTx) -> Self {
         let secret = t.transaction.secret.clone().map(|s| Secret::from(s.0));
-        let access_list = t.access_list
+        let access_list = t
+            .access_list
             .into_iter()
             .map(|elem| {
-                (elem.address.into(), elem.storage_keys
-                    .into_iter()
-                    .map(|a| a.into())
-                    .collect())
-                })
+                (
+                    elem.address.into(),
+                    elem.storage_keys.into_iter().map(|x| x.into()).collect(),
+                )
+            })
             .collect();
 
         let transaction: Transaction = t.transaction.into();
-        let tx = TypedTransaction::AccessList(AccessListTx{transaction, access_list});
+        let tx = TypedTransaction::AccessList(AccessListTx {
+            transaction,
+            access_list,
+        });
 
         match secret {
             Some(s) => tx.sign(&s, None),

--- a/crates/ethjson/Cargo.toml
+++ b/crates/ethjson/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
+common-types = { path = "../ethcore/types", features = ["test-helpers"] }
+ethkey = { path = "../accounts/ethkey" }
 ethereum-types = "0.4"
 rustc-hex = "1.0"
 serde = "1.0"

--- a/crates/ethjson/src/blockchain/transaction.rs
+++ b/crates/ethjson/src/blockchain/transaction.rs
@@ -41,7 +41,7 @@ pub struct Transaction {
 
 pub type AccessList = Vec<AccessListItem>;
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AccessListItem {
     pub address: H160,

--- a/crates/ethjson/src/lib.rs
+++ b/crates/ethjson/src/lib.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
+extern crate common_types as types;
 extern crate ethereum_types;
+extern crate ethkey;
 extern crate rustc_hex;
 extern crate serde;
 extern crate serde_json;

--- a/crates/ethjson/src/state/mod.rs
+++ b/crates/ethjson/src/state/mod.rs
@@ -21,6 +21,6 @@ pub mod state;
 pub mod test;
 pub mod transaction;
 
-pub use self::{log::Log, state::State, test::Test, transaction::Transaction};
+pub use self::{log::Log, state::State, test::Test, transaction:: {Transaction, TypedTransaction, AccessListTx}};
 pub use blockchain::State as AccountState;
 pub use vm::Env;

--- a/crates/ethjson/src/state/mod.rs
+++ b/crates/ethjson/src/state/mod.rs
@@ -21,6 +21,11 @@ pub mod state;
 pub mod test;
 pub mod transaction;
 
-pub use self::{log::Log, state::State, test::Test, transaction:: {Transaction, TypedTransaction, AccessListTx}};
+pub use self::{
+    log::Log,
+    state::State,
+    test::Test,
+    transaction::{AccessListTx, Transaction, TypedTransaction},
+};
 pub use blockchain::State as AccountState;
 pub use vm::Env;

--- a/crates/ethjson/src/state/mod.rs
+++ b/crates/ethjson/src/state/mod.rs
@@ -21,11 +21,6 @@ pub mod state;
 pub mod test;
 pub mod transaction;
 
-pub use self::{
-    log::Log,
-    state::State,
-    test::Test,
-    transaction::{AccessListTx, Transaction, TypedTransaction},
-};
+pub use self::{log::Log, state::State, test::Test, transaction::Transaction};
 pub use blockchain::State as AccountState;
 pub use vm::Env;

--- a/crates/ethjson/src/state/test.rs
+++ b/crates/ethjson/src/state/test.rs
@@ -21,7 +21,7 @@ use hash::{Address, H256};
 use maybe::MaybeEmpty;
 use serde_json::{self, Error};
 use spec::ForkSpec;
-use state::{AccountState, Env, Transaction, AccessListTx, TypedTransaction};
+use state::{AccessListTx, AccountState, Env, Transaction, TypedTransaction};
 use std::{collections::BTreeMap, io::Read};
 use uint::Uint;
 
@@ -69,8 +69,8 @@ pub struct State {
 pub struct MultiTransaction {
     /// Transaction data set.
     pub data: Vec<Bytes>,
-	/// Optional access list
-	pub access_lists: Option<Vec<Option<Vec<AccessList>>>>,
+    /// Optional access list
+    pub access_lists: Option<Vec<Option<Vec<AccessList>>>>,
     /// Gas limit set.
     pub gas_limit: Vec<Uint>,
     /// Gas price.
@@ -89,7 +89,6 @@ pub struct MultiTransaction {
 impl MultiTransaction {
     /// Build transaction with given indexes.
     pub fn select(&self, indexes: &PostStateIndexes) -> TypedTransaction {
-
         let transaction = Transaction {
             data: self.data[indexes.data as usize].clone(),
             gas_limit: self.gas_limit[indexes.gas as usize].clone(),
@@ -101,8 +100,11 @@ impl MultiTransaction {
         };
 
         if let Some(access_lists) = self.access_lists.as_ref() {
-            if let Some(access_list) = access_lists[indexes.data as usize].clone() { //intentionally reused index from data
-                return TypedTransaction::AccessList(AccessListTx {transaction, access_list})
+            if let Some(access_list) = access_lists[indexes.data as usize].clone() {
+                return TypedTransaction::AccessList(AccessListTx {
+                    transaction,
+                    access_list,
+                });
             }
         }
 
@@ -128,7 +130,7 @@ pub struct AccessList {
     /// Address
     pub address: Address,
     /// Storage keys
-    pub storage_keys: Vec<H256>
+    pub storage_keys: Vec<H256>,
 }
 
 /// State test indexed state result deserialization.
@@ -157,7 +159,7 @@ mod tests {
 			"value" : [ "0x00", "0x01", "0x02" ]
 		}"#;
         let _deserialized: MultiTransaction = serde_json::from_str(s).unwrap();
-		println!("_deserialized = {:?}", _deserialized);
+        println!("_deserialized = {:?}", _deserialized);
     }
 
     #[test]
@@ -191,7 +193,7 @@ mod tests {
 			"value" : [ "0x00", "0x01", "0x02" ]
 		}"#;
         let _deserialized: MultiTransaction = serde_json::from_str(s).unwrap();
-		println!("_deserialized = {:?}", _deserialized);
+        println!("_deserialized = {:?}", _deserialized);
     }
 
     #[test]

--- a/crates/ethjson/src/state/test.rs
+++ b/crates/ethjson/src/state/test.rs
@@ -119,26 +119,28 @@ impl MultiTransaction {
                 if let Some(access_list) = access_lists[indexes.data as usize].clone() {
                     //access list type of transaction
 
-                    return sign_with_secret(
-                        TypedTransaction::AccessList(AccessListTx {
-                            transaction,
-                            access_list: access_list
-                                .into_iter()
-                                .map(|elem| {
-                                    (
-                                        elem.address.into(),
-                                        elem.storage_keys.into_iter().map(Into::into).collect(),
-                                    )
-                                })
-                                .collect(),
-                        }),
-                        secret,
-                    );
+                    let access_list = access_list
+                        .into_iter()
+                        .map(|elem| {
+                            (
+                                elem.address.into(),
+                                elem.storage_keys.into_iter().map(Into::into).collect(),
+                            )
+                        })
+                        .collect();
+
+                    let tx = TypedTransaction::AccessList(AccessListTx {
+                        transaction,
+                        access_list,
+                    });
+
+                    return sign_with_secret(tx, secret);
                 }
             }
         }
 
-        sign_with_secret(TypedTransaction::Legacy(transaction), secret)
+        let tx = TypedTransaction::Legacy(transaction);
+        sign_with_secret(tx, secret)
     }
 }
 

--- a/crates/ethjson/src/state/test.rs
+++ b/crates/ethjson/src/state/test.rs
@@ -179,7 +179,6 @@ mod tests {
 			"value" : [ "0x00", "0x01", "0x02" ]
 		}"#;
         let _deserialized: MultiTransaction = serde_json::from_str(s).unwrap();
-        println!("_deserialized = {:?}", _deserialized);
     }
 
     #[test]
@@ -213,7 +212,6 @@ mod tests {
 			"value" : [ "0x00", "0x01", "0x02" ]
 		}"#;
         let _deserialized: MultiTransaction = serde_json::from_str(s).unwrap();
-        println!("_deserialized = {:?}", _deserialized);
     }
 
     #[test]

--- a/crates/ethjson/src/state/transaction.rs
+++ b/crates/ethjson/src/state/transaction.rs
@@ -21,14 +21,6 @@ use hash::{Address, H256};
 use maybe::MaybeEmpty;
 use uint::Uint;
 
-use super::test::AccessList;
-
-#[derive(Debug, PartialEq)]
-pub enum TypedTransaction {
-    Legacy(Transaction),
-    AccessList(AccessListTx),
-}
-
 /// State test transaction deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,12 +40,6 @@ pub struct Transaction {
     pub to: MaybeEmpty<Address>,
     /// Value.
     pub value: Uint,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct AccessListTx {
-    pub transaction: Transaction,
-    pub access_list: Vec<AccessList>,
 }
 
 #[cfg(test)]

--- a/crates/ethjson/src/state/transaction.rs
+++ b/crates/ethjson/src/state/transaction.rs
@@ -21,6 +21,15 @@ use hash::{Address, H256};
 use maybe::MaybeEmpty;
 use uint::Uint;
 
+use super::test::AccessList;
+
+#[derive(Debug, PartialEq)]
+pub enum TypedTransaction
+{
+    Legacy(Transaction),
+    AccessList(AccessListTx),
+}
+
 /// State test transaction deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -42,6 +51,12 @@ pub struct Transaction {
     pub value: Uint,
 }
 
+#[derive(Debug, PartialEq)]
+pub struct AccessListTx {
+    pub transaction: Transaction,
+    pub access_list: Vec<AccessList>,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json;
@@ -51,6 +66,7 @@ mod tests {
     fn transaction_deserialization() {
         let s = r#"{
 			"data" : "",
+            "accessLists": null,
 			"gasLimit" : "0x2dc6c0",
 			"gasPrice" : "0x01",
 			"nonce" : "0x00",

--- a/crates/ethjson/src/state/transaction.rs
+++ b/crates/ethjson/src/state/transaction.rs
@@ -51,7 +51,7 @@ mod tests {
     fn transaction_deserialization() {
         let s = r#"{
 			"data" : "",
-            "accessLists": null,
+			"accessLists": null,
 			"gasLimit" : "0x2dc6c0",
 			"gasPrice" : "0x01",
 			"nonce" : "0x00",

--- a/crates/ethjson/src/state/transaction.rs
+++ b/crates/ethjson/src/state/transaction.rs
@@ -24,8 +24,7 @@ use uint::Uint;
 use super::test::AccessList;
 
 #[derive(Debug, PartialEq)]
-pub enum TypedTransaction
-{
+pub enum TypedTransaction {
     Legacy(Transaction),
     AccessList(AccessListTx),
 }


### PR DESCRIPTION
Added TypedTransaction structure for tests to be equivalent to ethcore structures.
Added access lists to MultiTransaction structure for deserialization of json files.

Any refactor suggestions and comments on the code are welcomed.