### PR TITLE
ethcore/snapshot: fix double-lock in Service::feed_chunk

### DIFF
--- a/crates/ethcore/src/snapshot/service.rs
+++ b/crates/ethcore/src/snapshot/service.rs
@@ -766,7 +766,7 @@ impl Service {
             | Err(Error(SnapshotErrorKind::Snapshot(SnapshotError::RestorationAborted), _)) => (),
             Err(e) => {
                 warn!("Encountered error during snapshot restoration: {}", e);
-                *self.restoration.lock() = None;
+                *restoration = None;
                 *self.status.lock() = RestorationStatus::Failed;
                 let _ = fs::remove_dir_all(self.restoration_dir());
             }


### PR DESCRIPTION
A double-lock bug can happen in `Service::feed_chunk()`:
The first lock is at L763, the second at L769.
The fix reuses the `restoration` returned by the first lock.
https://github.com/openethereum/openethereum/blob/efb80e10324973223a8d7e64941b795aa6156e48/crates/ethcore/src/snapshot/service.rs#L761-L769
