### PR TITLE
AuRa multi block reward

### DIFF
--- a/crates/ethcore/src/engines/authority_round/mod.rs
+++ b/crates/ethcore/src/engines/authority_round/mod.rs
@@ -80,7 +80,7 @@ pub struct AuthorityRoundParams {
     /// Immediate transitions.
     pub immediate_transitions: bool,
     /// Block reward in base units.
-    pub block_reward: U256,
+    pub block_reward: BTreeMap<BlockNumber, U256>,
     /// Block reward contract transition block.
     pub block_reward_contract_transition: u64,
     /// Block reward contract.
@@ -113,7 +113,24 @@ impl From<ethjson::spec::AuthorityRoundParams> for AuthorityRoundParams {
             validate_score_transition: p.validate_score_transition.map_or(0, Into::into),
             validate_step_transition: p.validate_step_transition.map_or(0, Into::into),
             immediate_transitions: p.immediate_transitions.unwrap_or(false),
-            block_reward: p.block_reward.map_or_else(Default::default, Into::into),
+            block_reward: p.block_reward.map_or_else(
+                || {
+                    let mut ret = BTreeMap::new();
+                    ret.insert(0, U256::zero());
+                    ret
+                },
+                |reward| match reward {
+                    ethjson::spec::BlockReward::Single(reward) => {
+                        let mut ret = BTreeMap::new();
+                        ret.insert(0, reward.into());
+                        ret
+                    }
+                    ethjson::spec::BlockReward::Multi(multi) => multi
+                        .into_iter()
+                        .map(|(block, reward)| (block.into(), reward.into()))
+                        .collect(),
+                },
+            ),
             block_reward_contract_transition: p
                 .block_reward_contract_transition
                 .map_or(0, Into::into),
@@ -457,7 +474,7 @@ pub struct AuthorityRound {
     empty_steps: Mutex<BTreeSet<EmptyStep>>,
     epoch_manager: Mutex<EpochManager>,
     immediate_transitions: bool,
-    block_reward: U256,
+    block_reward: BTreeMap<BlockNumber, U256>,
     block_reward_contract_transition: u64,
     block_reward_contract: Option<BlockRewardContract>,
     maximum_uncle_count_transition: u64,
@@ -1372,10 +1389,11 @@ impl Engine<EthereumMachine> for AuthorityRound {
         }
 
         let author = *block.header.author();
+        let number = block.header.number();
         beneficiaries.push((author, RewardKind::Author));
 
         let rewards: Vec<_> = match self.block_reward_contract {
-            Some(ref c) if block.header.number() >= self.block_reward_contract_transition => {
+            Some(ref c) if number >= self.block_reward_contract_transition => {
                 let mut call = super::default_system_or_code_call(&self.machine, block);
 
                 let rewards = c.reward(&beneficiaries, &mut call)?;
@@ -1384,10 +1402,18 @@ impl Engine<EthereumMachine> for AuthorityRound {
                     .map(|(author, amount)| (author, RewardKind::External, amount))
                     .collect()
             }
-            _ => beneficiaries
-                .into_iter()
-                .map(|(author, reward_kind)| (author, reward_kind, self.block_reward))
-                .collect(),
+            _ => {
+                let (_, reward) = self.block_reward.iter()
+                .rev()
+                .find(|&(block, _)| *block <= number)
+                .expect("Current block's reward is not found; this indicates a chain config error; qed");
+                let reward = *reward;
+
+                beneficiaries
+                    .into_iter()
+                    .map(|(author, reward_kind)| (author, reward_kind, reward))
+                    .collect()
+            }
         };
 
         block_reward::apply_block_rewards(&rewards, block, &self.machine)

--- a/crates/ethjson/src/spec/authority_round.rs
+++ b/crates/ethjson/src/spec/authority_round.rs
@@ -16,7 +16,7 @@
 
 //! Authority params deserialization.
 
-use super::ValidatorSet;
+use super::{BlockReward, ValidatorSet};
 use bytes::Bytes;
 use hash::Address;
 use uint::Uint;
@@ -40,7 +40,7 @@ pub struct AuthorityRoundParams {
     /// Whether transitions should be immediate.
     pub immediate_transitions: Option<bool>,
     /// Reward per block in wei.
-    pub block_reward: Option<Uint>,
+    pub block_reward: Option<BlockReward>,
     /// Block at which the block reward contract should start being used.
     pub block_reward_contract_transition: Option<Uint>,
     /// Block reward contract address (setting the block reward contract
@@ -75,6 +75,7 @@ mod tests {
     use serde_json;
     use spec::{authority_round::AuthorityRound, validator_set::ValidatorSet};
     use uint::Uint;
+    use super::BlockReward;
 
     #[test]
     fn authority_round_deserialization() {
@@ -110,5 +111,9 @@ mod tests {
             deserialized.params.maximum_uncle_count,
             Some(Uint(5.into()))
         );
+        assert_eq!(
+            deserialized.params.block_reward,
+            Some(BlockReward::Single(Uint(5000000.into())))
+        )
     }
 }


### PR DESCRIPTION
Requested in discord.
It does not change old specs, it adds support for changing block rewards in AuRa spec.
Same code is used in ethash spec.