### PR TITLE
Migrate compare_and_swap to compare_exchange

### DIFF
--- a/crates/ethcore/src/engines/authority_round/mod.rs
+++ b/crates/ethcore/src/engines/authority_round/mod.rs
@@ -1187,7 +1187,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
     /// `Seal::None` will be returned.
     fn generate_seal(&self, block: &ExecutedBlock, parent: &Header) -> Seal {
         // first check to avoid generating signature most of the time
-        // (but there's still a race to the `compare_and_swap`)
+        // (but there's still a race to the `compare_exchange`)
         if !self.step.can_propose.load(AtomicOrdering::SeqCst) {
             trace!(target: "engine", "Aborting seal generation. Can't propose.");
             return Seal::None;
@@ -1245,7 +1245,8 @@ impl Engine<EthereumMachine> for AuthorityRound {
                 if self
                     .step
                     .can_propose
-                    .compare_and_swap(true, false, AtomicOrdering::SeqCst)
+                    .compare_exchange(true, false, AtomicOrdering::SeqCst, AtomicOrdering::SeqCst)
+                    .is_ok()
                 {
                     self.generate_empty_step(header.parent_hash());
                 }
@@ -1266,11 +1267,12 @@ impl Engine<EthereumMachine> for AuthorityRound {
             )) {
                 trace!(target: "engine", "generate_seal: Issuing a block for step {}.", step);
 
-                // only issue the seal if we were the first to reach the compare_and_swap.
+                // only issue the seal if we were the first to reach the compare_exchange.
                 if self
                     .step
                     .can_propose
-                    .compare_and_swap(true, false, AtomicOrdering::SeqCst)
+                    .compare_exchange(true, false, AtomicOrdering::SeqCst, AtomicOrdering::SeqCst)
+                    .is_ok()
                 {
                     // we can drop all accumulated empty step messages that are
                     // older than the parent step since we're including them in

--- a/crates/ethcore/src/engines/instant_seal.rs
+++ b/crates/ethcore/src/engines/instant_seal.rs
@@ -81,12 +81,16 @@ impl<M: Machine> Engine<M> for InstantSeal<M> {
             // Return a regular seal if the given block is _higher_ than
             // the last sealed one
             if block_number > last_sealed_block {
-                let prev_last_sealed_block = self.last_sealed_block.compare_and_swap(
-                    last_sealed_block,
-                    block_number,
-                    Ordering::SeqCst,
-                );
-                if prev_last_sealed_block == last_sealed_block {
+                if self
+                    .last_sealed_block
+                    .compare_exchange(
+                        last_sealed_block,
+                        block_number,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_ok()
+                {
                     return Seal::Regular(Vec::new());
                 }
             }

--- a/crates/ethcore/src/snapshot/service.rs
+++ b/crates/ethcore/src/snapshot/service.rs
@@ -516,7 +516,8 @@ impl Service {
     pub fn take_snapshot(&self, client: &Client, num: u64) -> Result<(), Error> {
         if self
             .taking_snapshot
-            .compare_and_swap(false, true, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
         {
             info!(
                 "Skipping snapshot at #{} as another one is currently in-progress.",

--- a/crates/ethcore/src/verification/queue/mod.rs
+++ b/crates/ethcore/src/verification/queue/mod.rs
@@ -181,8 +181,13 @@ impl QueueSignal {
 
         if self
             .signalled
-            .compare_and_swap(false, true, AtomicOrdering::Relaxed)
-            == false
+            .compare_exchange(
+                false,
+                true,
+                AtomicOrdering::Relaxed,
+                AtomicOrdering::Relaxed,
+            )
+            .is_ok()
         {
             let channel = self.message_channel.lock().clone();
             if let Err(e) = channel.send_sync(ClientIoMessage::BlockVerified) {
@@ -199,8 +204,13 @@ impl QueueSignal {
 
         if self
             .signalled
-            .compare_and_swap(false, true, AtomicOrdering::Relaxed)
-            == false
+            .compare_exchange(
+                false,
+                true,
+                AtomicOrdering::Relaxed,
+                AtomicOrdering::Relaxed,
+            )
+            .is_ok()
         {
             let channel = self.message_channel.lock().clone();
             if let Err(e) = channel.send(ClientIoMessage::BlockVerified) {


### PR DESCRIPTION
Currently, building generates warnings about `compare_and_swap` being deprecated, so this [migrates](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicBool.html#migrating-to-compare_exchange-and-compare_exchange_weak) it to `compare_exchange`.