### PR TITLE
Strict memory order

### DIFF
--- a/bin/oe/stratum.rs
+++ b/bin/oe/stratum.rs
@@ -39,7 +39,7 @@ struct StratumControlService {
 impl ControlService for StratumControlService {
 	fn shutdown(&self) -> bool {
 		trace!(target: "hypervisor", "Received shutdown from control service");
-		self.stop.store(true, ::std::sync::atomic::Ordering::Relaxed);
+		self.stop.store(true, ::std::sync::atomic::Ordering::SeqCst);
 		true
 	}
 }

--- a/crates/concensus/miner/price-info/src/lib.rs
+++ b/crates/concensus/miner/price-info/src/lib.rs
@@ -207,11 +207,11 @@ mod test {
         // when
         let bb = b.clone();
         price_info.get(move |_| {
-            bb.store(true, Ordering::Relaxed);
+            bb.store(true, Ordering::SeqCst);
         });
 
         // then
-        assert_eq!(b.load(Ordering::Relaxed), false);
+        assert_eq!(b.load(Ordering::SeqCst), false);
     }
 
     #[test]
@@ -225,10 +225,10 @@ mod test {
         // when
         let bb = b.clone();
         price_info.get(move |_| {
-            bb.store(true, Ordering::Relaxed);
+            bb.store(true, Ordering::SeqCst);
         });
 
         // then
-        assert_eq!(b.load(Ordering::Relaxed), false);
+        assert_eq!(b.load(Ordering::SeqCst), false);
     }
 }

--- a/crates/concensus/miner/src/pool/queue.rs
+++ b/crates/concensus/miner/src/pool/queue.rs
@@ -480,7 +480,7 @@ impl TransactionQueue {
         // We want to clear stale transactions from the queue as well.
         // (Transactions that are occuping the queue for a long time without being included)
         let stale_id = {
-            let current_id = self.insertion_id.load(atomic::Ordering::Relaxed);
+            let current_id = self.insertion_id.load(atomic::Ordering::SeqCst);
             // wait at least for half of the queue to be replaced
             let gap = self.pool.read().options().max_count / 2;
             // but never less than 100 transactions

--- a/crates/ethcore/service/src/stop_guard.rs
+++ b/crates/ethcore/service/src/stop_guard.rs
@@ -34,6 +34,6 @@ impl StopGuard {
 
 impl Drop for StopGuard {
     fn drop(&mut self) {
-        self.flag.store(true, Ordering::Relaxed)
+        self.flag.store(true, Ordering::SeqCst)
     }
 }

--- a/crates/ethcore/src/client/test_client.rs
+++ b/crates/ethcore/src/client/test_client.rs
@@ -237,7 +237,7 @@ impl TestBlockChainClient {
 
     /// Set block queue size for testing
     pub fn set_queue_size(&self, size: usize) {
-        self.queue_size.store(size, AtomicOrder::Relaxed);
+        self.queue_size.store(size, AtomicOrder::SeqCst);
     }
 
     /// Set timestamp assigned to latest sealed block
@@ -402,7 +402,7 @@ impl TestBlockChainClient {
 
     /// Returns true if the client has been disabled.
     pub fn is_disabled(&self) -> bool {
-        self.disabled.load(AtomicOrder::Relaxed)
+        self.disabled.load(AtomicOrder::SeqCst)
     }
 }
 
@@ -959,7 +959,7 @@ impl BlockChainClient for TestBlockChainClient {
 
     fn queue_info(&self) -> QueueInfo {
         QueueInfo {
-            verified_queue_size: self.queue_size.load(AtomicOrder::Relaxed),
+            verified_queue_size: self.queue_size.load(AtomicOrder::SeqCst),
             unverified_queue_size: 0,
             verifying_queue_size: 0,
             max_queue_size: 0,
@@ -1019,7 +1019,7 @@ impl BlockChainClient for TestBlockChainClient {
     }
 
     fn disable(&self) {
-        self.disabled.store(true, AtomicOrder::Relaxed);
+        self.disabled.store(true, AtomicOrder::SeqCst);
     }
 
     fn pruning_info(&self) -> PruningInfo {

--- a/crates/ethcore/src/snapshot/mod.rs
+++ b/crates/ethcore/src/snapshot/mod.rs
@@ -127,34 +127,34 @@ pub struct Progress {
 impl Progress {
     /// Reset the progress.
     pub fn reset(&self) {
-        self.accounts.store(0, Ordering::Release);
-        self.blocks.store(0, Ordering::Release);
-        self.size.store(0, Ordering::Release);
-        self.abort.store(false, Ordering::Release);
+        self.accounts.store(0, Ordering::SeqCst);
+        self.blocks.store(0, Ordering::SeqCst);
+        self.size.store(0, Ordering::SeqCst);
+        self.abort.store(false, Ordering::SeqCst);
 
         // atomic fence here to ensure the others are written first?
         // logs might very rarely get polluted if not.
-        self.done.store(false, Ordering::Release);
+        self.done.store(false, Ordering::SeqCst);
     }
 
     /// Get the number of accounts snapshotted thus far.
     pub fn accounts(&self) -> usize {
-        self.accounts.load(Ordering::Acquire)
+        self.accounts.load(Ordering::SeqCst)
     }
 
     /// Get the number of blocks snapshotted thus far.
     pub fn blocks(&self) -> usize {
-        self.blocks.load(Ordering::Acquire)
+        self.blocks.load(Ordering::SeqCst)
     }
 
     /// Get the written size of the snapshot in bytes.
     pub fn size(&self) -> u64 {
-        self.size.load(Ordering::Acquire)
+        self.size.load(Ordering::SeqCst)
     }
 
     /// Whether the snapshot is complete.
     pub fn done(&self) -> bool {
-        self.done.load(Ordering::Acquire)
+        self.done.load(Ordering::SeqCst)
     }
 }
 /// Take a snapshot using the given blockchain, starting block hash, and database, writing into the given writer.

--- a/crates/ethcore/src/verification/queue/mod.rs
+++ b/crates/ethcore/src/verification/queue/mod.rs
@@ -175,7 +175,7 @@ struct QueueSignal {
 impl QueueSignal {
     fn set_sync(&self) {
         // Do not signal when we are about to close
-        if self.deleting.load(AtomicOrdering::Relaxed) {
+        if self.deleting.load(AtomicOrdering::SeqCst) {
             return;
         }
 
@@ -184,8 +184,8 @@ impl QueueSignal {
             .compare_exchange(
                 false,
                 true,
-                AtomicOrdering::Relaxed,
-                AtomicOrdering::Relaxed,
+                AtomicOrdering::SeqCst,
+                AtomicOrdering::SeqCst,
             )
             .is_ok()
         {
@@ -198,7 +198,7 @@ impl QueueSignal {
 
     fn set_async(&self) {
         // Do not signal when we are about to close
-        if self.deleting.load(AtomicOrdering::Relaxed) {
+        if self.deleting.load(AtomicOrdering::SeqCst) {
             return;
         }
 
@@ -207,8 +207,8 @@ impl QueueSignal {
             .compare_exchange(
                 false,
                 true,
-                AtomicOrdering::Relaxed,
-                AtomicOrdering::Relaxed,
+                AtomicOrdering::SeqCst,
+                AtomicOrdering::SeqCst,
             )
             .is_ok()
         {
@@ -220,7 +220,7 @@ impl QueueSignal {
     }
 
     fn reset(&self) {
-        self.signalled.store(false, AtomicOrdering::Relaxed);
+        self.signalled.store(false, AtomicOrdering::SeqCst);
     }
 }
 
@@ -499,9 +499,9 @@ impl<K: Kind> VerificationQueue<K> {
         verified.clear();
 
         let sizes = &self.verification.sizes;
-        sizes.unverified.store(0, AtomicOrdering::Release);
-        sizes.verifying.store(0, AtomicOrdering::Release);
-        sizes.verified.store(0, AtomicOrdering::Release);
+        sizes.unverified.store(0, AtomicOrdering::SeqCst);
+        sizes.verifying.store(0, AtomicOrdering::SeqCst);
+        sizes.verified.store(0, AtomicOrdering::SeqCst);
         *self.total_difficulty.write() = 0.into();
 
         self.processing.write().clear();
@@ -728,7 +728,7 @@ impl<K: Kind> VerificationQueue<K> {
                 .verification
                 .sizes
                 .unverified
-                .load(AtomicOrdering::Acquire);
+                .load(AtomicOrdering::SeqCst);
 
             (len, size + len * size_of::<K::Unverified>())
         };
@@ -738,7 +738,7 @@ impl<K: Kind> VerificationQueue<K> {
                 .verification
                 .sizes
                 .verifying
-                .load(AtomicOrdering::Acquire);
+                .load(AtomicOrdering::SeqCst);
             (len, size + len * size_of::<Verifying<K>>())
         };
         let (verified_len, verified_bytes) = {
@@ -747,7 +747,7 @@ impl<K: Kind> VerificationQueue<K> {
                 .verification
                 .sizes
                 .verified
-                .load(AtomicOrdering::Acquire);
+                .load(AtomicOrdering::SeqCst);
             (len, size + len * size_of::<K::Verified>())
         };
 

--- a/crates/ethcore/src/verification/queue/mod.rs
+++ b/crates/ethcore/src/verification/queue/mod.rs
@@ -181,12 +181,7 @@ impl QueueSignal {
 
         if self
             .signalled
-            .compare_exchange(
-                false,
-                true,
-                AtomicOrdering::SeqCst,
-                AtomicOrdering::SeqCst,
-            )
+            .compare_exchange(false, true, AtomicOrdering::SeqCst, AtomicOrdering::SeqCst)
             .is_ok()
         {
             let channel = self.message_channel.lock().clone();
@@ -204,12 +199,7 @@ impl QueueSignal {
 
         if self
             .signalled
-            .compare_exchange(
-                false,
-                true,
-                AtomicOrdering::SeqCst,
-                AtomicOrdering::SeqCst,
-            )
+            .compare_exchange(false, true, AtomicOrdering::SeqCst, AtomicOrdering::SeqCst)
             .is_ok()
         {
             let channel = self.message_channel.lock().clone();

--- a/crates/ethcore/sync/src/chain/mod.rs
+++ b/crates/ethcore/sync/src/chain/mod.rs
@@ -489,7 +489,7 @@ impl ChainSyncApi {
 
         if self
             .priority_tasks_gate
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Release)
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
             .is_err()
         {
             return;
@@ -552,7 +552,7 @@ impl ChainSyncApi {
         // Process as many items as we can until the deadline is reached.
         loop {
             if work().is_none() {
-                self.priority_tasks_gate.store(false, Ordering::Release);
+                self.priority_tasks_gate.store(false, Ordering::SeqCst);
                 return;
             }
         }

--- a/crates/net/network-devp2p/src/host.rs
+++ b/crates/net/network-devp2p/src/host.rs
@@ -464,7 +464,7 @@ impl Host {
     }
 
     pub fn stop(&self, io: &IoContext<NetworkIoMessage>) {
-        self.stopping.store(true, AtomicOrdering::Release);
+        self.stopping.store(true, AtomicOrdering::SeqCst);
         let mut to_kill = Vec::new();
         for e in self.sessions.read().iter() {
             let mut s = e.lock();
@@ -1168,7 +1168,7 @@ impl IoHandler<NetworkIoMessage> for Host {
     }
 
     fn stream_readable(&self, io: &IoContext<NetworkIoMessage>, stream: StreamToken) {
-        if self.stopping.load(AtomicOrdering::Acquire) {
+        if self.stopping.load(AtomicOrdering::SeqCst) {
             return;
         }
         match stream {
@@ -1180,7 +1180,7 @@ impl IoHandler<NetworkIoMessage> for Host {
     }
 
     fn stream_writable(&self, io: &IoContext<NetworkIoMessage>, stream: StreamToken) {
-        if self.stopping.load(AtomicOrdering::Acquire) {
+        if self.stopping.load(AtomicOrdering::SeqCst) {
             return;
         }
         match stream {
@@ -1191,7 +1191,7 @@ impl IoHandler<NetworkIoMessage> for Host {
     }
 
     fn timeout(&self, io: &IoContext<NetworkIoMessage>, token: TimerToken) {
-        if self.stopping.load(AtomicOrdering::Acquire) {
+        if self.stopping.load(AtomicOrdering::SeqCst) {
             return;
         }
         match token {
@@ -1253,7 +1253,7 @@ impl IoHandler<NetworkIoMessage> for Host {
     }
 
     fn message(&self, io: &IoContext<NetworkIoMessage>, message: &NetworkIoMessage) {
-        if self.stopping.load(AtomicOrdering::Acquire) {
+        if self.stopping.load(AtomicOrdering::SeqCst) {
             return;
         }
         match *message {

--- a/crates/net/network-devp2p/tests/tests.rs
+++ b/crates/net/network-devp2p/tests/tests.rs
@@ -73,11 +73,11 @@ impl TestProtocol {
     }
 
     pub fn got_timeout(&self) -> bool {
-        self.got_timeout.load(AtomicOrdering::Relaxed)
+        self.got_timeout.load(AtomicOrdering::SeqCst)
     }
 
     pub fn got_disconnect(&self) -> bool {
-        self.got_disconnect.load(AtomicOrdering::Relaxed)
+        self.got_disconnect.load(AtomicOrdering::SeqCst)
     }
 }
 
@@ -101,13 +101,13 @@ impl NetworkProtocolHandler for TestProtocol {
     }
 
     fn disconnected(&self, _io: &dyn NetworkContext, _peer: &PeerId) {
-        self.got_disconnect.store(true, AtomicOrdering::Relaxed);
+        self.got_disconnect.store(true, AtomicOrdering::SeqCst);
     }
 
     /// Timer function called after a timeout created with `NetworkContext::timeout`.
     fn timeout(&self, _io: &dyn NetworkContext, timer: TimerToken) {
         assert_eq!(timer, 0);
-        self.got_timeout.store(true, AtomicOrdering::Relaxed);
+        self.got_timeout.store(true, AtomicOrdering::SeqCst);
     }
 }
 

--- a/crates/rpc/src/v1/informant.rs
+++ b/crates/rpc/src/v1/informant.rs
@@ -171,7 +171,7 @@ impl RpcStats {
 
     /// Returns number of open sessions
     pub fn sessions(&self) -> usize {
-        self.active_sessions.load(atomic::Ordering::Relaxed)
+        self.active_sessions.load(atomic::Ordering::SeqCst)
     }
 
     /// Returns requests rate

--- a/crates/util/cli-signer/rpc-client/src/client.rs
+++ b/crates/util/cli-signer/rpc-client/src/client.rs
@@ -259,7 +259,7 @@ impl Rpc {
     {
         let (c, p) = oneshot::<Result<JsonValue, RpcError>>();
 
-        let id = self.counter.fetch_add(1, Ordering::Relaxed);
+        let id = self.counter.fetch_add(1, Ordering::SeqCst);
         self.pending.insert(id, c);
 
         let request = MethodCall {


### PR DESCRIPTION
Having Relaxed/Aquire/Release memory order can leave our code to CPU to optimize and in the end switch order of execution of commands that could become bugs that are hard to detect, debug and prove if they are correct or not, it should be used very sparingly and only when it is certain it does not affect code that surrounds it. SeqCst should be the default for any atomic operations. I don't expect any performance penalty by switching to SeqCst for our bottlenecks are tied to DB.