### PR TITLE
[devops] Upgrade alpine docker to v1.13.2

### DIFF
--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.3 AS builder
+FROM alpine:3.13.2 AS builder
 
 # show backtraces
 ENV RUST_BACKTRACE 1
@@ -18,7 +18,7 @@ COPY . /openethereum
 RUN cargo build --release --features final --target x86_64-alpine-linux-musl --verbose
 RUN strip target/x86_64-alpine-linux-musl/release/openethereum
 
-FROM alpine:3.12.3
+FROM alpine:3.13.2
 
 # show backtraces
 ENV RUST_BACKTRACE 1


### PR DESCRIPTION
This will allow us to use rust v1.47