### PR TITLE
Refactoring ethcore::client::Client god-type, part 1 of N

### DIFF
--- a/crates/ethcore/src/client/blockchain.rs
+++ b/crates/ethcore/src/client/blockchain.rs
@@ -21,8 +21,7 @@ use super::{
     info::{BlockChain, BlockInfo},
     io::IoClient,
     traits::TransactionRequest,
-    AccountData, BadBlocks, ChainInfo, Executed, ImportBlock, Mode, StateOrBlock, TraceFilter,
-    TransactionInfo,
+    AccountData, BadBlocks, Executed, ImportBlock, Mode, StateOrBlock, TraceFilter,
 };
 
 use crate::{

--- a/crates/ethcore/src/client/blockchain.rs
+++ b/crates/ethcore/src/client/blockchain.rs
@@ -31,8 +31,7 @@ use crate::{
 use blockchain::{BlockProvider, BlockReceipts, TreeRoute};
 use bytes::Bytes;
 use call_contract::{CallContract, RegistryInfo};
-use client::info::ScheduleInfo;
-use client::traits::Nonce;
+use client::{info::ScheduleInfo, traits::Nonce};
 use db::DBValue;
 use ethcore_miner::pool::VerifiedTransaction;
 use ethereum_types::{Address, H256, U256};
@@ -40,8 +39,7 @@ use hash::keccak;
 use itertools::Itertools;
 use miner::MinerService;
 use state;
-use trace;
-use trace::Database;
+use trace::{self, Database};
 use trie::Trie;
 use types::{
     basic_account::BasicAccount,

--- a/crates/ethcore/src/client/blockchain.rs
+++ b/crates/ethcore/src/client/blockchain.rs
@@ -1,0 +1,977 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{cmp, collections::BTreeMap, sync::Arc};
+
+use super::{
+    client::Client,
+    info::{BlockChain, BlockInfo},
+    io::IoClient,
+    traits::TransactionRequest,
+    AccountData, BadBlocks, ChainInfo, Executed, ImportBlock, Mode, StateOrBlock, TraceFilter,
+    TransactionInfo,
+};
+
+use crate::{
+    engines::MAX_UNCLE_AGE, executed::CallError, trace::LocalizedTrace, verification::QueueInfo,
+};
+use blockchain::{BlockProvider, BlockReceipts, TreeRoute};
+use bytes::Bytes;
+use call_contract::{CallContract, RegistryInfo};
+use client::info::ScheduleInfo;
+use client::traits::Nonce;
+use db::DBValue;
+use ethcore_miner::pool::VerifiedTransaction;
+use ethereum_types::{Address, H256, U256};
+use hash::keccak;
+use itertools::Itertools;
+use miner::MinerService;
+use state;
+use trace;
+use trace::Database;
+use trie::Trie;
+use types::{
+    basic_account::BasicAccount,
+    block_status::BlockStatus,
+    call_analytics::CallAnalytics,
+    encoded,
+    ids::{BlockId, TraceId, TransactionId, UncleId},
+    log_entry::LocalizedLogEntry,
+    pruning_info::PruningInfo,
+    receipt::LocalizedReceipt,
+    transaction,
+    transaction::{LocalizedTransaction, SignedTransaction, TypedTransaction},
+    BlockNumber,
+};
+use vm::LastHashes;
+
+/// Blockchain database client. Owns and manages a blockchain and a block queue.
+pub trait BlockChainClient:
+    Sync
+    + Send
+    + AccountData
+    + BlockChain
+    + CallContract
+    + RegistryInfo
+    + ImportBlock
+    + IoClient
+    + BadBlocks
+{
+    /// Look up the block number for the given block ID.
+    fn block_number(&self, id: BlockId) -> Option<BlockNumber>;
+
+    /// Get raw block body data by block id.
+    /// Block body is an RLP list of two items: uncles and transactions.
+    fn block_body(&self, id: BlockId) -> Option<encoded::Body>;
+
+    /// Get block status by block header hash.
+    fn block_status(&self, id: BlockId) -> BlockStatus;
+
+    /// Get block total difficulty.
+    fn block_total_difficulty(&self, id: BlockId) -> Option<U256>;
+
+    /// Attempt to get address storage root at given block.
+    /// May not fail on BlockId::Latest.
+    fn storage_root(&self, address: &Address, id: BlockId) -> Option<H256>;
+
+    /// Get block hash.
+    fn block_hash(&self, id: BlockId) -> Option<H256>;
+
+    /// Get address code at given block's state.
+    fn code(&self, address: &Address, state: StateOrBlock) -> Option<Option<Bytes>>;
+
+    /// Get address code at the latest block's state.
+    fn latest_code(&self, address: &Address) -> Option<Bytes> {
+        self.code(address, BlockId::Latest.into())
+            .expect("code will return Some if given BlockId::Latest; qed")
+    }
+
+    /// Returns true if the given block is known and in the canon chain.
+    fn is_canon(&self, hash: &H256) -> bool;
+
+    /// Get address code hash at given block's state.
+
+    /// Get value of the storage at given position at the given block's state.
+    ///
+    /// May not return None if given BlockId::Latest.
+    /// Returns None if and only if the block's root hash has been pruned from the DB.
+    fn storage_at(&self, address: &Address, position: &H256, state: StateOrBlock) -> Option<H256>;
+
+    /// Get value of the storage at given position at the latest block's state.
+    fn latest_storage_at(&self, address: &Address, position: &H256) -> H256 {
+        self.storage_at(address, position, BlockId::Latest.into())
+			.expect("storage_at will return Some if given BlockId::Latest. storage_at was given BlockId::Latest. \
+			Therefore storage_at has returned Some; qed")
+    }
+
+    /// Get a list of all accounts in the block `id`, if fat DB is in operation, otherwise `None`.
+    /// If `after` is set the list starts with the following item.
+    fn list_accounts(
+        &self,
+        id: BlockId,
+        after: Option<&Address>,
+        count: u64,
+    ) -> Option<Vec<Address>>;
+
+    /// Get a list of all storage keys in the block `id`, if fat DB is in operation, otherwise `None`.
+    /// If `after` is set the list starts with the following item.
+    fn list_storage(
+        &self,
+        id: BlockId,
+        account: &Address,
+        after: Option<&H256>,
+        count: u64,
+    ) -> Option<Vec<H256>>;
+
+    /// Get transaction with given hash.
+    fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction>;
+
+    /// Get uncle with given id.
+    fn uncle(&self, id: UncleId) -> Option<encoded::Header>;
+
+    /// Get transaction receipt with given hash.
+    fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt>;
+
+    /// Get localized receipts for all transaction in given block.
+    fn localized_block_receipts(&self, id: BlockId) -> Option<Vec<LocalizedReceipt>>;
+
+    /// Get a tree route between `from` and `to`.
+    /// See `BlockChain::tree_route`.
+    fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute>;
+
+    /// Get all possible uncle hashes for a block.
+    fn find_uncles(&self, hash: &H256) -> Option<Vec<H256>>;
+
+    /// Get block receipts data by block header hash.
+    fn block_receipts(&self, hash: &H256) -> Option<BlockReceipts>;
+
+    /// Get block queue information.
+    fn queue_info(&self) -> QueueInfo;
+
+    /// Returns true if block queue is empty.
+    fn is_queue_empty(&self) -> bool {
+        self.queue_info().is_empty()
+    }
+
+    /// Clear block queue and abort all import activity.
+    fn clear_queue(&self);
+
+    /// Get the registrar address, if it exists.
+    fn additional_params(&self) -> BTreeMap<String, String>;
+
+    /// Returns logs matching given filter. If one of the filtering block cannot be found, returns the block id that caused the error.
+    fn logs(&self, filter: types::filter::Filter) -> Result<Vec<LocalizedLogEntry>, BlockId>;
+
+    /// Replays a given transaction for inspection.
+    fn replay(&self, t: TransactionId, analytics: CallAnalytics) -> Result<Executed, CallError>;
+
+    /// Replays all the transactions in a given block for inspection.
+    fn replay_block_transactions(
+        &self,
+        block: BlockId,
+        analytics: CallAnalytics,
+    ) -> Result<Box<dyn Iterator<Item = (H256, Executed)>>, CallError>;
+
+    /// Returns traces matching given filter.
+    fn filter_traces(&self, filter: TraceFilter) -> Option<Vec<LocalizedTrace>>;
+
+    /// Returns trace with given id.
+    fn trace(&self, trace: TraceId) -> Option<LocalizedTrace>;
+
+    /// Returns traces created by transaction.
+    fn transaction_traces(&self, trace: TransactionId) -> Option<Vec<LocalizedTrace>>;
+
+    /// Returns traces created by transaction from block.
+    fn block_traces(&self, trace: BlockId) -> Option<Vec<LocalizedTrace>>;
+
+    /// Get last hashes starting from best block.
+    fn last_hashes(&self) -> LastHashes;
+
+    /// List all ready transactions that should be propagated to other peers.
+    fn transactions_to_propagate(&self) -> Vec<Arc<VerifiedTransaction>>;
+
+    /// Sorted list of transaction gas prices from at least last sample_size blocks.
+    fn gas_price_corpus(&self, sample_size: usize) -> ::stats::Corpus<U256> {
+        let mut h = self.chain_info().best_block_hash;
+        let mut corpus = Vec::new();
+        while corpus.is_empty() {
+            for _ in 0..sample_size {
+                let block = match self.block(BlockId::Hash(h)) {
+                    Some(block) => block,
+                    None => return corpus.into(),
+                };
+
+                if block.number() == 0 {
+                    return corpus.into();
+                }
+                block
+                    .transaction_views()
+                    .iter()
+                    .foreach(|t| corpus.push(t.gas_price()));
+                h = block.parent_hash().clone();
+            }
+        }
+        corpus.into()
+    }
+
+    /// Get the preferred chain ID to sign on
+    fn signing_chain_id(&self) -> Option<u64>;
+
+    /// Get the chain spec name.
+    fn spec_name(&self) -> String;
+
+    /// Set the chain via a spec name.
+    fn set_spec_name(&self, spec_name: String) -> Result<(), ()>;
+
+    /// Disable the client from importing blocks. This cannot be undone in this session and indicates
+    /// that a subsystem has reason to believe this executable incapable of syncing the chain.
+    fn disable(&self);
+
+    /// Returns engine-related extra info for `BlockId`.
+    fn block_extra_info(&self, id: BlockId) -> Option<BTreeMap<String, String>>;
+
+    /// Returns engine-related extra info for `UncleId`.
+    fn uncle_extra_info(&self, id: UncleId) -> Option<BTreeMap<String, String>>;
+
+    /// Returns information about pruning/data availability.
+    fn pruning_info(&self) -> PruningInfo;
+
+    /// Returns a transaction signed with the key configured in the engine signer.
+    fn create_transaction(
+        &self,
+        tx_request: TransactionRequest,
+    ) -> Result<SignedTransaction, transaction::Error>;
+
+    /// Schedule state-altering transaction to be executed on the next pending
+    /// block with the given gas and nonce parameters.
+    fn transact(&self, tx_request: TransactionRequest) -> Result<(), transaction::Error>;
+
+    /// Get the address of the registry itself.
+    fn registrar_address(&self) -> Option<Address>;
+
+    /// Returns true, if underlying import queue is processing possible fork at the moment
+    fn is_processing_fork(&self) -> bool;
+
+    /// Get the mode.
+    fn mode(&self) -> Mode;
+
+    /// Set the mode.
+    fn set_mode(&self, mode: Mode);
+}
+
+/// Extended client interface for providing proofs of the state.
+pub trait ProvingBlockChainClient: BlockChainClient {
+    /// Prove account storage at a specific block id.
+    ///
+    /// Both provided keys assume a secure trie.
+    /// Returns a vector of raw trie nodes (in order from the root) proving the storage query.
+    fn prove_storage(&self, key1: H256, key2: H256, id: BlockId) -> Option<(Vec<Bytes>, H256)>;
+
+    /// Prove account existence at a specific block id.
+    /// The key is the keccak hash of the account's address.
+    /// Returns a vector of raw trie nodes (in order from the root) proving the query.
+    fn prove_account(&self, key1: H256, id: BlockId) -> Option<(Vec<Bytes>, BasicAccount)>;
+
+    /// Prove execution of a transaction at the given block.
+    /// Returns the output of the call and a vector of database items necessary
+    /// to reproduce it.
+    fn prove_transaction(
+        &self,
+        transaction: SignedTransaction,
+        id: BlockId,
+    ) -> Option<(Bytes, Vec<DBValue>)>;
+
+    /// Get an epoch change signal by block hash.
+    fn epoch_signal(&self, hash: H256) -> Option<Vec<u8>>;
+}
+
+impl BlockChainClient for Client {
+    fn replay(&self, id: TransactionId, analytics: CallAnalytics) -> Result<Executed, CallError> {
+        let address = self
+            .transaction_address(id)
+            .ok_or(CallError::TransactionNotFound)?;
+        let block = BlockId::Hash(address.block_hash);
+
+        const PROOF: &'static str =
+            "The transaction address contains a valid index within block; qed";
+        Ok(self
+            .replay_block_transactions(block, analytics)?
+            .nth(address.index)
+            .expect(PROOF)
+            .1)
+    }
+
+    fn replay_block_transactions(
+        &self,
+        block: BlockId,
+        analytics: CallAnalytics,
+    ) -> Result<Box<dyn Iterator<Item = (H256, Executed)>>, CallError> {
+        let mut env_info = self.env_info(block).ok_or(CallError::StatePruned)?;
+        let body = self.block_body(block).ok_or(CallError::StatePruned)?;
+        let mut state = self
+            .state_at_beginning(block)
+            .ok_or(CallError::StatePruned)?;
+        let txs = body.transactions();
+        let engine = self.engine();
+
+        const PROOF: &'static str =
+            "Transactions fetched from blockchain; blockchain transactions are valid; qed";
+        const EXECUTE_PROOF: &'static str = "Transaction replayed; qed";
+
+        Ok(Box::new(txs.into_iter().map(move |t| {
+            let transaction_hash = t.hash();
+            let t = SignedTransaction::new(t).expect(PROOF);
+            let machine = engine.machine();
+            let x = Self::do_virtual_call(machine, &env_info, &mut state, &t, analytics)
+                .expect(EXECUTE_PROOF);
+            env_info.gas_used = env_info.gas_used + x.gas_used;
+            (transaction_hash, x)
+        })))
+    }
+
+    fn disable(&self) {
+        self.set_mode(Mode::Off);
+        self.disable();
+        self.clear_queue();
+    }
+
+    fn spec_name(&self) -> String {
+        self.config.spec_name.clone()
+    }
+
+    fn is_canon(&self, hash: &H256) -> bool {
+        self.chain.read().is_canon(hash)
+    }
+
+    /// Get the mode.
+    fn mode(&self) -> Mode {
+        Client::mode(&self)
+    }
+
+    /// Set the mode.
+    fn set_mode(&self, mode: Mode) {
+        Client::set_mode(&self, mode);
+    }
+
+    fn set_spec_name(&self, new_spec_name: String) -> Result<(), ()> {
+        trace!(target: "mode", "Client::set_spec_name({:?})", new_spec_name);
+        if !self.enabled() {
+            return Err(());
+        }
+        if let Some(ref h) = *self.exit_handler.lock() {
+            (*h)(new_spec_name);
+            Ok(())
+        } else {
+            warn!("Not hypervised; cannot change chain.");
+            Err(())
+        }
+    }
+
+    fn block_number(&self, id: BlockId) -> Option<BlockNumber> {
+        self.block_number_ref(&id)
+    }
+
+    fn block_body(&self, id: BlockId) -> Option<encoded::Body> {
+        let chain = self.chain.read();
+
+        Self::block_hash(&chain, id).and_then(|hash| chain.block_body(&hash))
+    }
+
+    fn block_status(&self, id: BlockId) -> BlockStatus {
+        let chain = self.chain.read();
+        match Self::block_hash(&chain, id) {
+            Some(ref hash) if chain.is_known(hash) => BlockStatus::InChain,
+            Some(hash) => self.importer.block_queue.status(&hash).into(),
+            None => BlockStatus::Unknown,
+        }
+    }
+
+    fn is_processing_fork(&self) -> bool {
+        let chain = self.chain.read();
+        self.importer
+            .block_queue
+            .is_processing_fork(&chain.best_block_hash(), &chain)
+    }
+
+    fn block_total_difficulty(&self, id: BlockId) -> Option<U256> {
+        let chain = self.chain.read();
+
+        Self::block_hash(&chain, id)
+            .and_then(|hash| chain.block_details(&hash))
+            .map(|d| d.total_difficulty)
+    }
+
+    fn storage_root(&self, address: &Address, id: BlockId) -> Option<H256> {
+        self.state_at(id)
+            .and_then(|s| s.storage_root(address).ok())
+            .and_then(|x| x)
+    }
+
+    fn block_hash(&self, id: BlockId) -> Option<H256> {
+        let chain = self.chain.read();
+        Self::block_hash(&chain, id)
+    }
+
+    fn code(&self, address: &Address, state: StateOrBlock) -> Option<Option<Bytes>> {
+        let result = match state {
+            StateOrBlock::State(s) => s.code(address).ok(),
+            StateOrBlock::Block(id) => self.state_at(id).and_then(|s| s.code(address).ok()),
+        };
+
+        // Converting from `Option<Option<Arc<Bytes>>>` to `Option<Option<Bytes>>`
+        result.map(|c| c.map(|c| (&*c).clone()))
+    }
+
+    fn storage_at(&self, address: &Address, position: &H256, state: StateOrBlock) -> Option<H256> {
+        match state {
+            StateOrBlock::State(s) => s.storage_at(address, position).ok(),
+            StateOrBlock::Block(id) => self
+                .state_at(id)
+                .and_then(|s| s.storage_at(address, position).ok()),
+        }
+    }
+
+    fn list_accounts(
+        &self,
+        id: BlockId,
+        after: Option<&Address>,
+        count: u64,
+    ) -> Option<Vec<Address>> {
+        if !self.factories.trie.is_fat() {
+            trace!(target: "fatdb", "list_accounts: Not a fat DB");
+            return None;
+        }
+
+        let state = match self.state_at(id) {
+            Some(state) => state,
+            _ => return None,
+        };
+
+        let (root, db) = state.drop();
+        let db = &db.as_hash_db();
+        let trie = match self.factories.trie.readonly(db, &root) {
+            Ok(trie) => trie,
+            _ => {
+                trace!(target: "fatdb", "list_accounts: Couldn't open the DB");
+                return None;
+            }
+        };
+
+        let mut iter = match trie.iter() {
+            Ok(iter) => iter,
+            _ => return None,
+        };
+
+        if let Some(after) = after {
+            if let Err(e) = iter.seek(after.as_bytes()) {
+                trace!(target: "fatdb", "list_accounts: Couldn't seek the DB: {:?}", e);
+            } else {
+                // Position the iterator after the `after` element
+                iter.next();
+            }
+        }
+
+        let accounts = iter
+            .filter_map(|item| item.ok().map(|(addr, _)| Address::from_slice(&addr)))
+            .take(count as usize)
+            .collect();
+
+        Some(accounts)
+    }
+
+    fn list_storage(
+        &self,
+        id: BlockId,
+        account: &Address,
+        after: Option<&H256>,
+        count: u64,
+    ) -> Option<Vec<H256>> {
+        if !self.factories.trie.is_fat() {
+            trace!(target: "fatdb", "list_storage: Not a fat DB");
+            return None;
+        }
+
+        let state = match self.state_at(id) {
+            Some(state) => state,
+            _ => return None,
+        };
+
+        let root = match state.storage_root(account) {
+            Ok(Some(root)) => root,
+            _ => return None,
+        };
+
+        let (_, db) = state.drop();
+        let account_db = &self
+            .factories
+            .accountdb
+            .readonly(db.as_hash_db(), keccak(account));
+        let account_db = &account_db.as_hash_db();
+        let trie = match self.factories.trie.readonly(account_db, &root) {
+            Ok(trie) => trie,
+            _ => {
+                trace!(target: "fatdb", "list_storage: Couldn't open the DB");
+                return None;
+            }
+        };
+
+        let mut iter = match trie.iter() {
+            Ok(iter) => iter,
+            _ => return None,
+        };
+
+        if let Some(after) = after {
+            if let Err(e) = iter.seek(after.as_bytes()) {
+                trace!(target: "fatdb", "list_storage: Couldn't seek the DB: {:?}", e);
+            } else {
+                // Position the iterator after the `after` element
+                iter.next();
+            }
+        }
+
+        let keys = iter
+            .filter_map(|item| item.ok().map(|(key, _)| H256::from_slice(&key)))
+            .take(count as usize)
+            .collect();
+
+        Some(keys)
+    }
+
+    fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction> {
+        self.transaction_address(id)
+            .and_then(|address| self.chain.read().transaction(&address))
+    }
+
+    fn uncle(&self, id: UncleId) -> Option<encoded::Header> {
+        let index = id.position;
+        self.block_body(id.block)
+            .and_then(|body| body.view().uncle_rlp_at(index))
+            .map(encoded::Header::new)
+    }
+
+    fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt> {
+        // NOTE Don't use block_receipts here for performance reasons
+        let address = self.transaction_address(id)?;
+        let hash = address.block_hash;
+        let chain = self.chain.read();
+        let number = chain.block_number(&hash)?;
+        let body = chain.block_body(&hash)?;
+        let mut receipts = chain.block_receipts(&hash)?.receipts;
+        receipts.truncate(address.index + 1);
+
+        let transaction = body
+            .view()
+            .localized_transaction_at(&hash, number, address.index)?;
+        let receipt = receipts.pop()?;
+        let gas_used = receipts.last().map_or_else(|| 0.into(), |r| r.gas_used);
+        let no_of_logs = receipts
+            .into_iter()
+            .map(|receipt| receipt.logs.len())
+            .sum::<usize>();
+
+        let receipt = super::transaction_receipt(
+            self.engine().machine(),
+            transaction,
+            receipt,
+            gas_used,
+            no_of_logs,
+        );
+        Some(receipt)
+    }
+
+    fn localized_block_receipts(&self, id: BlockId) -> Option<Vec<LocalizedReceipt>> {
+        let hash = self.block_hash(id)?;
+
+        let chain = self.chain.read();
+        let receipts = chain.block_receipts(&hash)?;
+        let number = chain.block_number(&hash)?;
+        let body = chain.block_body(&hash)?;
+        let engine = self.engine();
+
+        let mut gas_used = 0.into();
+        let mut no_of_logs = 0;
+
+        Some(
+            body.view()
+                .localized_transactions(&hash, number)
+                .into_iter()
+                .zip(receipts.receipts)
+                .map(move |(transaction, receipt)| {
+                    let result = super::transaction_receipt(
+                        engine.machine(),
+                        transaction,
+                        receipt,
+                        gas_used,
+                        no_of_logs,
+                    );
+                    gas_used = result.cumulative_gas_used;
+                    no_of_logs += result.logs.len();
+                    result
+                })
+                .collect(),
+        )
+    }
+
+    fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {
+        let chain = self.chain.read();
+        match chain.is_known(from) && chain.is_known(to) {
+            true => chain.tree_route(from.clone(), to.clone()),
+            false => None,
+        }
+    }
+
+    fn find_uncles(&self, hash: &H256) -> Option<Vec<H256>> {
+        self.chain.read().find_uncle_hashes(hash, MAX_UNCLE_AGE)
+    }
+
+    fn block_receipts(&self, hash: &H256) -> Option<BlockReceipts> {
+        self.chain.read().block_receipts(hash)
+    }
+
+    fn queue_info(&self) -> QueueInfo {
+        self.importer.block_queue.queue_info()
+    }
+
+    fn is_queue_empty(&self) -> bool {
+        self.importer.block_queue.is_empty()
+    }
+
+    fn clear_queue(&self) {
+        self.importer.block_queue.clear();
+    }
+
+    fn additional_params(&self) -> BTreeMap<String, String> {
+        self.engine().additional_params().into_iter().collect()
+    }
+
+    fn logs(&self, filter: types::filter::Filter) -> Result<Vec<LocalizedLogEntry>, BlockId> {
+        let chain = self.chain.read();
+
+        // First, check whether `filter.from_block` and `filter.to_block` is on the canon chain. If so, we can use the
+        // optimized version.
+        let is_canon = |id| {
+            match id {
+                // If it is referred by number, then it is always on the canon chain.
+                &BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) => true,
+                // If it is referred by hash, we see whether a hash -> number -> hash conversion gives us the same
+                // result.
+                &BlockId::Hash(ref hash) => chain.is_canon(hash),
+            }
+        };
+
+        let blocks = if is_canon(&filter.from_block) && is_canon(&filter.to_block) {
+            // If we are on the canon chain, use bloom filter to fetch required hashes.
+            //
+            // If we are sure the block does not exist (where val > best_block_number), then return error. Note that we
+            // don't need to care about pending blocks here because RPC query sets pending back to latest (or handled
+            // pending logs themselves).
+            let from = match self.block_number_ref(&filter.from_block) {
+                Some(val) if val <= chain.best_block_number() => val,
+                _ => return Err(filter.from_block.clone()),
+            };
+            let to = match self.block_number_ref(&filter.to_block) {
+                Some(val) if val <= chain.best_block_number() => val,
+                _ => return Err(filter.to_block.clone()),
+            };
+
+            // If from is greater than to, then the current bloom filter behavior is to just return empty
+            // result. There's no point to continue here.
+            if from > to {
+                return Err(filter.to_block.clone());
+            }
+
+            chain
+                .blocks_with_bloom(&filter.bloom_possibilities(), from, to)
+                .into_iter()
+                .filter_map(|n| chain.block_hash(n))
+                .collect::<Vec<H256>>()
+        } else {
+            // Otherwise, we use a slower version that finds a link between from_block and to_block.
+            let from_hash = Self::block_hash(&chain, filter.from_block)
+                .ok_or_else(|| filter.from_block.clone())?;
+            let from_number = chain
+                .block_number(&from_hash)
+                .ok_or_else(|| BlockId::Hash(from_hash))?;
+            let to_hash =
+                Self::block_hash(&chain, filter.to_block).ok_or_else(|| filter.to_block.clone())?;
+
+            let blooms = filter.bloom_possibilities();
+            let bloom_match = |header: &encoded::Header| {
+                blooms
+                    .iter()
+                    .any(|bloom| header.log_bloom().contains_bloom(bloom))
+            };
+
+            let (blocks, last_hash) = {
+                let mut blocks = Vec::new();
+                let mut current_hash = to_hash;
+
+                loop {
+                    let header = chain
+                        .block_header_data(&current_hash)
+                        .ok_or_else(|| BlockId::Hash(current_hash))?;
+                    if bloom_match(&header) {
+                        blocks.push(current_hash);
+                    }
+
+                    // Stop if `from` block is reached.
+                    if header.number() <= from_number {
+                        break;
+                    }
+                    current_hash = header.parent_hash();
+                }
+
+                blocks.reverse();
+                (blocks, current_hash)
+            };
+
+            // Check if we've actually reached the expected `from` block.
+            if last_hash != from_hash || blocks.is_empty() {
+                // In this case, from_hash is the cause (for not matching last_hash).
+                return Err(BlockId::Hash(from_hash));
+            }
+
+            blocks
+        };
+
+        Ok(chain.logs(blocks, |entry| filter.matches(entry), filter.limit))
+    }
+
+    fn filter_traces(&self, filter: TraceFilter) -> Option<Vec<LocalizedTrace>> {
+        if !self.tracedb.read().tracing_enabled() {
+            return None;
+        }
+
+        let start = self.block_number(filter.range.start)?;
+        let end = self.block_number(filter.range.end)?;
+
+        let db_filter = trace::Filter {
+            range: start as usize..end as usize,
+            from_address: filter.from_address.into(),
+            to_address: filter.to_address.into(),
+        };
+
+        let traces = self
+            .tracedb
+            .read()
+            .filter(&db_filter)
+            .into_iter()
+            .skip(filter.after.unwrap_or(0))
+            .take(filter.count.unwrap_or(usize::max_value()))
+            .collect();
+        Some(traces)
+    }
+
+    fn trace(&self, trace: TraceId) -> Option<LocalizedTrace> {
+        if !self.tracedb.read().tracing_enabled() {
+            return None;
+        }
+
+        let trace_address = trace.address;
+        self.transaction_address(trace.transaction)
+            .and_then(|tx_address| {
+                self.block_number(BlockId::Hash(tx_address.block_hash))
+                    .and_then(|number| {
+                        self.tracedb
+                            .read()
+                            .trace(number, tx_address.index, trace_address)
+                    })
+            })
+    }
+
+    fn transaction_traces(&self, transaction: TransactionId) -> Option<Vec<LocalizedTrace>> {
+        if !self.tracedb.read().tracing_enabled() {
+            return None;
+        }
+
+        self.transaction_address(transaction)
+            .and_then(|tx_address| {
+                self.block_number(BlockId::Hash(tx_address.block_hash))
+                    .and_then(|number| {
+                        self.tracedb
+                            .read()
+                            .transaction_traces(number, tx_address.index)
+                    })
+            })
+    }
+
+    fn block_traces(&self, block: BlockId) -> Option<Vec<LocalizedTrace>> {
+        if !self.tracedb.read().tracing_enabled() {
+            return None;
+        }
+
+        self.block_number(block)
+            .and_then(|number| self.tracedb.read().block_traces(number))
+    }
+
+    fn last_hashes(&self) -> LastHashes {
+        (*self.build_last_hashes(&self.chain.read().best_block_hash())).clone()
+    }
+
+    fn transactions_to_propagate(&self) -> Vec<Arc<VerifiedTransaction>> {
+        const PROPAGATE_FOR_BLOCKS: u32 = 4;
+        const MIN_TX_TO_PROPAGATE: usize = 256;
+
+        let block_gas_limit = *self.best_block_header().gas_limit();
+        let min_tx_gas: U256 = self.latest_schedule().tx_gas.into();
+
+        let max_len = if min_tx_gas.is_zero() {
+            usize::max_value()
+        } else {
+            cmp::max(
+                MIN_TX_TO_PROPAGATE,
+                cmp::min(
+                    (block_gas_limit / min_tx_gas) * PROPAGATE_FOR_BLOCKS,
+                    // never more than usize
+                    usize::max_value().into(),
+                )
+                .as_u64() as usize,
+            )
+        };
+        self.importer
+            .miner
+            .ready_transactions(self, max_len, ::miner::PendingOrdering::Priority)
+    }
+
+    fn signing_chain_id(&self) -> Option<u64> {
+        self.engine().signing_chain_id(&self.latest_env_info())
+    }
+
+    fn block_extra_info(&self, id: BlockId) -> Option<BTreeMap<String, String>> {
+        self.block_header_decoded(id)
+            .map(|header| self.engine().extra_info(&header))
+    }
+
+    fn uncle_extra_info(&self, id: UncleId) -> Option<BTreeMap<String, String>> {
+        self.uncle(id)
+            .and_then(|h| h.decode().map(|dh| self.engine().extra_info(&dh)).ok())
+    }
+
+    fn pruning_info(&self) -> PruningInfo {
+        PruningInfo {
+            earliest_chain: self.chain.read().first_block_number().unwrap_or(1),
+            earliest_state: self
+                .state_db
+                .read()
+                .journal_db()
+                .earliest_era()
+                .unwrap_or(0),
+        }
+    }
+
+    fn create_transaction(
+        &self,
+        TransactionRequest {
+            action,
+            data,
+            gas,
+            gas_price,
+            nonce,
+        }: TransactionRequest,
+    ) -> Result<SignedTransaction, transaction::Error> {
+        let authoring_params = self.importer.miner.authoring_params();
+        let service_transaction_checker = self.importer.miner.service_transaction_checker();
+        let gas_price = if let Some(checker) = service_transaction_checker {
+            match checker.check_address(self, authoring_params.author) {
+                Ok(true) => U256::zero(),
+                _ => gas_price.unwrap_or_else(|| self.importer.miner.sensible_gas_price()),
+            }
+        } else {
+            self.importer.miner.sensible_gas_price()
+        };
+        let transaction = TypedTransaction::Legacy(transaction::Transaction {
+            nonce: nonce.unwrap_or_else(|| self.latest_nonce(&authoring_params.author)),
+            action,
+            gas: gas.unwrap_or_else(|| self.importer.miner.sensible_gas_limit()),
+            gas_price,
+            value: U256::zero(),
+            data,
+        });
+        let chain_id = self.engine().signing_chain_id(&self.latest_env_info());
+        let signature = self
+            .engine()
+            .sign(transaction.signature_hash(chain_id))
+            .map_err(|e| transaction::Error::InvalidSignature(e.to_string()))?;
+        Ok(SignedTransaction::new(
+            transaction.with_signature(signature, chain_id),
+        )?)
+    }
+
+    fn transact(&self, tx_request: TransactionRequest) -> Result<(), transaction::Error> {
+        let signed = self.create_transaction(tx_request)?;
+        self.importer
+            .miner
+            .import_own_transaction(self, signed.into())
+    }
+
+    fn registrar_address(&self) -> Option<Address> {
+        self.registrar_address.clone()
+    }
+}
+
+impl ProvingBlockChainClient for Client {
+    fn prove_storage(&self, key1: H256, key2: H256, id: BlockId) -> Option<(Vec<Bytes>, H256)> {
+        self.state_at(id)
+            .and_then(move |state| state.prove_storage(key1, key2).ok())
+    }
+
+    fn prove_account(
+        &self,
+        key1: H256,
+        id: BlockId,
+    ) -> Option<(Vec<Bytes>, ::types::basic_account::BasicAccount)> {
+        self.state_at(id)
+            .and_then(move |state| state.prove_account(key1).ok())
+    }
+
+    fn prove_transaction(
+        &self,
+        transaction: SignedTransaction,
+        id: BlockId,
+    ) -> Option<(Bytes, Vec<DBValue>)> {
+        let (header, mut env_info) = match (self.block_header(id), self.env_info(id)) {
+            (Some(s), Some(e)) => (s, e),
+            _ => return None,
+        };
+
+        env_info.gas_limit = transaction.tx().gas.clone();
+        let mut jdb = self.state_db.read().journal_db().boxed_clone();
+
+        state::prove_transaction_virtual(
+            jdb.as_hash_db_mut(),
+            header.state_root().clone(),
+            &transaction,
+            self.engine().machine(),
+            &env_info,
+            self.factories.clone(),
+        )
+    }
+
+    fn epoch_signal(&self, hash: H256) -> Option<Vec<u8>> {
+        // pending transitions are never deleted, and do not contain
+        // finality proofs by definition.
+        self.chain
+            .read()
+            .get_pending_transition(hash)
+            .map(|pending| pending.proof)
+    }
+}
+
+/// resets the blockchain
+pub trait BlockChainReset {
+    /// reset to best_block - n
+    fn reset(&self, num: u32) -> Result<(), String>;
+}

--- a/crates/ethcore/src/client/call.rs
+++ b/crates/ethcore/src/client/call.rs
@@ -1,0 +1,173 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::client::{Call, Client};
+use crate::executed::CallError;
+use crate::state::State;
+use error::ExecutionError;
+use ethereum_types::U256;
+use evm::EnvInfo;
+use executive::{Executed, Executive, TransactOptions};
+use transaction_ext::Transaction;
+use types::{call_analytics::CallAnalytics, header::Header, transaction::SignedTransaction};
+
+impl Call for Client {
+    type State = State<::state_db::StateDB>;
+
+    fn call(
+        &self,
+        transaction: &SignedTransaction,
+        analytics: CallAnalytics,
+        state: &mut Self::State,
+        header: &Header,
+    ) -> Result<Executed, CallError> {
+        let env_info = EnvInfo {
+            number: header.number(),
+            author: header.author().clone(),
+            timestamp: header.timestamp(),
+            difficulty: header.difficulty().clone(),
+            last_hashes: self.build_last_hashes(header.parent_hash()),
+            gas_used: U256::default(),
+            gas_limit: U256::max_value(),
+        };
+        let engine = self.engine();
+        let machine = engine.machine();
+
+        Self::do_virtual_call(&machine, &env_info, state, transaction, analytics)
+    }
+
+    fn call_many(
+        &self,
+        transactions: &[(SignedTransaction, CallAnalytics)],
+        state: &mut Self::State,
+        header: &Header,
+    ) -> Result<Vec<Executed>, CallError> {
+        let mut env_info = EnvInfo {
+            number: header.number(),
+            author: header.author().clone(),
+            timestamp: header.timestamp(),
+            difficulty: header.difficulty().clone(),
+            last_hashes: self.build_last_hashes(header.parent_hash()),
+            gas_used: U256::default(),
+            gas_limit: U256::max_value(),
+        };
+
+        let mut results = Vec::with_capacity(transactions.len());
+        let engine = self.engine();
+        let machine = engine.machine();
+
+        for &(ref t, analytics) in transactions {
+            let ret = Self::do_virtual_call(machine, &env_info, state, t, analytics)?;
+            env_info.gas_used = ret.cumulative_gas_used;
+            results.push(ret);
+        }
+
+        Ok(results)
+    }
+
+    fn estimate_gas(
+        &self,
+        t: &SignedTransaction,
+        state: &Self::State,
+        header: &Header,
+    ) -> Result<U256, CallError> {
+        let (mut upper, max_upper, env_info) = {
+            let init = *header.gas_limit();
+            let max = init * U256::from(10);
+
+            let env_info = EnvInfo {
+                number: header.number(),
+                author: header.author().clone(),
+                timestamp: header.timestamp(),
+                difficulty: header.difficulty().clone(),
+                last_hashes: self.build_last_hashes(header.parent_hash()),
+                gas_used: U256::default(),
+                gas_limit: max,
+            };
+
+            (init, max, env_info)
+        };
+
+        let sender = t.sender();
+        let options = || TransactOptions::with_tracing().dont_check_nonce();
+
+        let exec = |gas| {
+            let mut tx = t.as_unsigned().clone();
+            tx.tx_mut().gas = gas;
+            let tx = tx.fake_sign(sender);
+
+            let mut clone = state.clone();
+            let engine = self.engine();
+            let machine = engine.machine();
+            let schedule = machine.schedule(env_info.number);
+            Executive::new(&mut clone, &env_info, &machine, &schedule)
+                .transact_virtual(&tx, options())
+        };
+
+        let cond = |gas| exec(gas).ok().map_or(false, |r| r.exception.is_none());
+
+        if !cond(upper) {
+            upper = max_upper;
+            match exec(upper) {
+                Ok(v) => {
+                    if let Some(exception) = v.exception {
+                        return Err(CallError::Exceptional(exception));
+                    }
+                }
+                Err(_e) => {
+                    trace!(target: "estimate_gas", "estimate_gas failed with {}", upper);
+                    let err = ExecutionError::Internal(format!(
+                        "Requires higher than upper limit of {}",
+                        upper
+                    ));
+                    return Err(err.into());
+                }
+            }
+        }
+        let lower = t
+            .tx()
+            .gas_required(&self.engine().schedule(env_info.number))
+            .into();
+        if cond(lower) {
+            trace!(target: "estimate_gas", "estimate_gas succeeded with {}", lower);
+            return Ok(lower);
+        }
+
+        /// Find transition point between `lower` and `upper` where `cond` changes from `false` to `true`.
+        /// Returns the lowest value between `lower` and `upper` for which `cond` returns true.
+        /// We assert: `cond(lower) = false`, `cond(upper) = true`
+        fn binary_chop<F, E>(mut lower: U256, mut upper: U256, mut cond: F) -> Result<U256, E>
+        where
+            F: FnMut(U256) -> bool,
+        {
+            while upper - lower > 1.into() {
+                let mid = (lower + upper) / 2;
+                trace!(target: "estimate_gas", "{} .. {} .. {}", lower, mid, upper);
+                let c = cond(mid);
+                match c {
+                    true => upper = mid,
+                    false => lower = mid,
+                };
+                trace!(target: "estimate_gas", "{} => {} .. {}", c, lower, upper);
+            }
+            Ok(upper)
+        }
+
+        // binary chop to non-excepting call with gas somewhere between 21000 and block gas limit
+        trace!(target: "estimate_gas", "estimate_gas chopping {} .. {}", lower, upper);
+        binary_chop(lower, upper, cond)
+    }
+}

--- a/crates/ethcore/src/client/call.rs
+++ b/crates/ethcore/src/client/call.rs
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::client::{Call, Client};
-use crate::executed::CallError;
-use crate::state::State;
+use crate::{
+    client::{Call, Client},
+    executed::CallError,
+    state::State,
+};
 use error::ExecutionError;
 use ethereum_types::U256;
 use evm::EnvInfo;

--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -1726,7 +1726,6 @@ pub fn transaction_receipt(
     }
 }
 
-
 /// Queue some items to be processed by IO client.
 pub struct IoChannelQueue {
     /// Using a *signed* integer for counting currently queued messages since the
@@ -1773,7 +1772,6 @@ impl IoChannelQueue {
         Ok(())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/ethcore/src/client/client.rs
+++ b/crates/ethcore/src/client/client.rs
@@ -18,10 +18,11 @@ use std::{
     cmp,
     collections::{BTreeMap, HashSet, VecDeque},
     convert::TryFrom,
+    fmt::{Display, Error as FmtError, Formatter},
     io::{BufRead, BufReader},
     str::{from_utf8, FromStr},
     sync::{
-        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering as AtomicOrdering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         Arc, Weak,
     },
     time::{Duration, Instant},
@@ -65,14 +66,16 @@ use call_contract::RegistryInfo;
 use client::{
     ancient_import::AncientVerifier,
     bad_blocks,
+    blockchain::*,
+    info::BlockChain as BlockChainTrait,
+    io::IoClient,
     traits::{ForceUpdateSealing, TransactionRequest},
-    AccountData, BadBlocks, Balance, BlockChain as BlockChainTrait, BlockChainClient,
-    BlockChainReset, BlockId, BlockInfo, BlockProducer, BroadcastProposalBlock, Call,
-    CallAnalytics, ChainInfo, ChainMessageType, ChainNotify, ChainRoute, ClientConfig,
-    ClientIoMessage, EngineInfo, ImportBlock, ImportExportBlocks, ImportSealedBlock, IoClient,
-    Mode, NewBlocks, Nonce, PrepareOpenBlock, ProvingBlockChainClient, PruningInfo, ReopenBlock,
-    ScheduleInfo, SealedBlockImporter, StateClient, StateInfo, StateOrBlock, TraceFilter, TraceId,
-    TransactionId, TransactionInfo, UncleId,
+    AccountData, BadBlocks, Balance, BlockId, BlockInfo, BlockProducer, BroadcastProposalBlock,
+    Call, CallAnalytics, ChainInfo, ChainMessageType, ChainNotify, ChainRoute, ClientConfig,
+    ClientIoMessage, EngineInfo, ImportBlock, ImportExportBlocks, ImportSealedBlock, NewBlocks,
+    Nonce, PrepareOpenBlock, PruningInfo, ReopenBlock, ScheduleInfo, SealedBlockImporter,
+    StateClient, StateInfo, StateOrBlock, TraceFilter, TraceId, TransactionId, TransactionInfo,
+    UncleId,
 };
 use engines::{
     epoch::PendingTransition, EngineError, EpochTransition, EthEngine, ForkChoice, SealingState,
@@ -90,7 +93,7 @@ use snapshot::{self, io as snapshot_io, SnapshotClient};
 use spec::Spec;
 use state::{self, State};
 use state_db::StateDB;
-use stats::{PrometheusMetrics, PrometheusRegistry};
+
 use trace::{
     self, Database as TraceDatabase, ImportRequest as TraceImportRequest, LocalizedTrace, TraceDB,
 };
@@ -169,44 +172,57 @@ impl SleepState {
     }
 }
 
-struct Importer {
-    /// Lock used during block import
-    pub import_lock: Mutex<()>, // FIXME Maybe wrap the whole `Importer` instead?
+/// Operating mode for the client.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Mode {
+    /// Always on.
+    Active,
+    /// Goes offline after client is inactive for some (given) time, but
+    /// comes back online after a while of inactivity.
+    Passive(Duration, Duration),
+    /// Goes offline after client is inactive for some (given) time and
+    /// stays inactive.
+    Dark(Duration),
+    /// Always off.
+    Off,
+}
 
-    /// Used to verify blocks
-    pub verifier: Box<dyn Verifier<Client>>,
-
-    /// Queue containing pending blocks
-    pub block_queue: BlockQueue,
-
-    /// Handles block sealing
-    pub miner: Arc<Miner>,
-
-    /// Ancient block verifier: import an ancient sequence of blocks in order from a starting epoch
-    pub ancient_verifier: AncientVerifier,
-
-    /// Ethereum engine to be used during import
-    pub engine: Arc<dyn EthEngine>,
-
-    /// A lru cache of recently detected bad blocks
-    pub bad_blocks: bad_blocks::BadBlocks,
+impl Display for Mode {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        match *self {
+            Mode::Active => write!(f, "active"),
+            Mode::Passive(..) => write!(f, "passive"),
+            Mode::Dark(..) => write!(f, "dark"),
+            Mode::Off => write!(f, "offline"),
+        }
+    }
 }
 
 /// Blockchain database client backed by a persistent database. Owns and manages a blockchain and a block queue.
 /// Call `import_block()` to import a block asynchronously; `flush_queue()` flushes the queue.
 pub struct Client {
+    /// Client configuration
+    pub config: ClientConfig,
+
+    /// Report on the status of client
+    pub report: RwLock<ClientReport>,
+
+    pub chain: RwLock<Arc<BlockChain>>,
+
+    pub factories: Factories,
+
+    pub registrar_address: Option<Address>,
+
+    pub importer: super::importer::Importer,
+
     /// Flag used to disable the client forever. Not to be confused with `liveness`.
     enabled: AtomicBool,
 
     /// Operating mode for the client
     mode: Mutex<Mode>,
 
-    chain: RwLock<Arc<BlockChain>>,
-    tracedb: RwLock<TraceDB<BlockChain>>,
+    pub tracedb: RwLock<TraceDB<BlockChain>>,
     engine: Arc<dyn EthEngine>,
-
-    /// Client configuration
-    config: ClientConfig,
 
     /// Database pruning strategy to use for StateDB
     pruning: journaldb::Algorithm,
@@ -215,33 +231,29 @@ pub struct Client {
     snapshotting_at: AtomicU64,
 
     /// Client uses this to store blocks, traces, etc.
-    db: RwLock<Arc<dyn BlockChainDB>>,
+    pub db: RwLock<Arc<dyn BlockChainDB>>,
 
-    state_db: RwLock<StateDB>,
-
-    /// Report on the status of client
-    report: RwLock<ClientReport>,
+    pub state_db: RwLock<StateDB>,
 
     sleep_state: Mutex<SleepState>,
 
     /// Flag changed by `sleep` and `wake_up` methods. Not to be confused with `enabled`.
     liveness: AtomicBool,
-    io_channel: RwLock<IoChannel<ClientIoMessage>>,
+    pub io_channel: RwLock<IoChannel<ClientIoMessage>>,
 
     /// List of actors to be notified on certain chain events
     notify: RwLock<Vec<Weak<dyn ChainNotify>>>,
 
     /// Queued transactions from IO
-    queue_transactions: IoChannelQueue,
+    pub queue_transactions: IoChannelQueue,
     /// Ancient blocks import queue
     /// Queued ancient blocks, make sure they are imported in order.
-    queued_ancient_blocks: Arc<RwLock<HashSet<H256>>>,
-    queued_ancient_blocks_executer: Mutex<Option<ExecutionQueue<(Unverified, Bytes)>>>,
+    pub queued_ancient_blocks: Arc<RwLock<HashSet<H256>>>,
+    pub queued_ancient_blocks_executer: Mutex<Option<ExecutionQueue<(Unverified, Bytes)>>>,
     /// Consensus messages import queue
-    queue_consensus_message: IoChannelQueue,
+    pub queue_consensus_message: IoChannelQueue,
 
     last_hashes: RwLock<VecDeque<H256>>,
-    factories: Factories,
 
     /// Number of eras kept in a journal before they are pruned
     history: u64,
@@ -249,627 +261,8 @@ pub struct Client {
     /// An action to be done if a mode/spec_name change happens
     on_user_defaults_change: Mutex<Option<Box<dyn FnMut(Option<Mode>) + 'static + Send>>>,
 
-    registrar_address: Option<Address>,
-
     /// A closure to call when we want to restart the client
-    exit_handler: Mutex<Option<Box<dyn Fn(String) + 'static + Send>>>,
-
-    importer: Importer,
-}
-
-impl Importer {
-    pub fn new(
-        config: &ClientConfig,
-        engine: Arc<dyn EthEngine>,
-        message_channel: IoChannel<ClientIoMessage>,
-        miner: Arc<Miner>,
-    ) -> Result<Importer, EthcoreError> {
-        let block_queue = BlockQueue::new(
-            config.queue.clone(),
-            engine.clone(),
-            message_channel.clone(),
-            config.verifier_type.verifying_seal(),
-        );
-
-        Ok(Importer {
-            import_lock: Mutex::new(()),
-            verifier: verification::new(config.verifier_type.clone()),
-            block_queue,
-            miner,
-            ancient_verifier: AncientVerifier::new(engine.clone()),
-            engine,
-            bad_blocks: Default::default(),
-        })
-    }
-
-    // t_nb 6.0 This is triggered by a message coming from a block queue when the block is ready for insertion
-    pub fn import_verified_blocks(&self, client: &Client) -> usize {
-        // Shortcut out if we know we're incapable of syncing the chain.
-        trace!(target: "block_import", "fn import_verified_blocks");
-        if !client.enabled.load(AtomicOrdering::SeqCst) {
-            self.block_queue.reset_verification_ready_signal();
-            return 0;
-        }
-
-        let max_blocks_to_import = client.config.max_round_blocks_to_import;
-        let (
-            imported_blocks,
-            import_results,
-            invalid_blocks,
-            imported,
-            proposed_blocks,
-            duration,
-            has_more_blocks_to_import,
-        ) = {
-            let mut imported_blocks = Vec::with_capacity(max_blocks_to_import);
-            let mut invalid_blocks = HashSet::new();
-            let proposed_blocks = Vec::with_capacity(max_blocks_to_import);
-            let mut import_results = Vec::with_capacity(max_blocks_to_import);
-
-            let _import_lock = self.import_lock.lock();
-            let blocks = self.block_queue.drain(max_blocks_to_import);
-            if blocks.is_empty() {
-                debug!(target: "block_import", "block_queue is empty");
-                self.block_queue.resignal_verification();
-                return 0;
-            }
-            trace_time!("import_verified_blocks");
-            let start = Instant::now();
-
-            for block in blocks {
-                let header = block.header.clone();
-                let bytes = block.bytes.clone();
-                let hash = header.hash();
-
-                let is_invalid = invalid_blocks.contains(header.parent_hash());
-                if is_invalid {
-                    debug!(
-                        target: "block_import",
-                        "Refusing block #{}({}) with invalid parent {}",
-                        header.number(),
-                        header.hash(),
-                        header.parent_hash()
-                    );
-                    invalid_blocks.insert(hash);
-                    continue;
-                }
-                // t_nb 7.0 check and lock block
-                match self.check_and_lock_block(&bytes, block, client) {
-                    Ok((closed_block, pending)) => {
-                        imported_blocks.push(hash);
-                        let transactions_len = closed_block.transactions.len();
-                        trace!(target:"block_import","Block #{}({}) check pass",header.number(),header.hash());
-                        // t_nb 8.0 commit block to db
-                        let route = self.commit_block(
-                            closed_block,
-                            &header,
-                            encoded::Block::new(bytes),
-                            pending,
-                            client,
-                        );
-                        trace!(target:"block_import","Block #{}({}) commited",header.number(),header.hash());
-                        import_results.push(route);
-                        client
-                            .report
-                            .write()
-                            .accrue_block(&header, transactions_len);
-                    }
-                    Err(err) => {
-                        self.bad_blocks.report(bytes, format!("{:?}", err));
-                        invalid_blocks.insert(hash);
-                    }
-                }
-            }
-
-            let imported = imported_blocks.len();
-            let invalid_blocks = invalid_blocks.into_iter().collect::<Vec<H256>>();
-
-            if !invalid_blocks.is_empty() {
-                self.block_queue.mark_as_bad(&invalid_blocks);
-            }
-            let has_more_blocks_to_import = !self.block_queue.mark_as_good(&imported_blocks);
-            (
-                imported_blocks,
-                import_results,
-                invalid_blocks,
-                imported,
-                proposed_blocks,
-                start.elapsed(),
-                has_more_blocks_to_import,
-            )
-        };
-
-        {
-            if !imported_blocks.is_empty() {
-                trace!(target:"block_import","Imported block, notify rest of system");
-                let route = ChainRoute::from(import_results.as_ref());
-
-                // t_nb 10 Notify miner about new included block.
-                if !has_more_blocks_to_import {
-                    self.miner.chain_new_blocks(
-                        client,
-                        &imported_blocks,
-                        &invalid_blocks,
-                        route.enacted(),
-                        route.retracted(),
-                        false,
-                    );
-                }
-
-                // t_nb 11 notify rest of system about new block inclusion
-                client.notify(|notify| {
-                    notify.new_blocks(NewBlocks::new(
-                        imported_blocks.clone(),
-                        invalid_blocks.clone(),
-                        route.clone(),
-                        Vec::new(),
-                        proposed_blocks.clone(),
-                        duration,
-                        has_more_blocks_to_import,
-                    ));
-                });
-            }
-        }
-        trace!(target:"block_import","Flush block to db");
-        let db = client.db.read();
-        db.key_value().flush().expect("DB flush failed.");
-
-        self.block_queue.resignal_verification();
-        trace!(target:"block_import","Resignal verifier");
-        imported
-    }
-
-    // t_nb 6.0.1 check and lock block,
-    fn check_and_lock_block(
-        &self,
-        bytes: &[u8],
-        block: PreverifiedBlock,
-        client: &Client,
-    ) -> EthcoreResult<(LockedBlock, Option<PendingTransition>)> {
-        let engine = &*self.engine;
-        let header = block.header.clone();
-
-        // Check the block isn't so old we won't be able to enact it.
-        // t_nb 7.1 check if block is older then last pruned block
-        let best_block_number = client.chain.read().best_block_number();
-        if client.pruning_info().earliest_state > header.number() {
-            warn!(target: "client", "Block import failed for #{} ({})\nBlock is ancient (current best block: #{}).", header.number(), header.hash(), best_block_number);
-            bail!("Block is ancient");
-        }
-
-        // t_nb 7.2 Check if parent is in chain
-        let parent = match client.block_header_decoded(BlockId::Hash(*header.parent_hash())) {
-            Some(h) => h,
-            None => {
-                warn!(target: "client", "Block import failed for #{} ({}): Parent not found ({}) ", header.number(), header.hash(), header.parent_hash());
-                bail!("Parent not found");
-            }
-        };
-
-        let chain = client.chain.read();
-        // t_nb 7.3 verify block family
-        let verify_family_result = self.verifier.verify_block_family(
-            &header,
-            &parent,
-            engine,
-            Some(verification::FullFamilyParams {
-                block: &block,
-                block_provider: &**chain,
-                client,
-            }),
-        );
-
-        if let Err(e) = verify_family_result {
-            warn!(target: "client", "Stage 3 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
-            bail!(e);
-        };
-
-        // t_nb 7.4 verify block external
-        let verify_external_result = self.verifier.verify_block_external(&header, engine);
-        if let Err(e) = verify_external_result {
-            warn!(target: "client", "Stage 4 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
-            bail!(e);
-        };
-
-        // Enact Verified Block
-        // t_nb 7.5 Get build last hashes. Get parent state db. Get epoch_transition
-        let last_hashes = client.build_last_hashes(header.parent_hash());
-
-        let db = client
-            .state_db
-            .read()
-            .boxed_clone_canon(header.parent_hash());
-
-        let is_epoch_begin = chain
-            .epoch_transition(parent.number(), *header.parent_hash())
-            .is_some();
-
-        // t_nb 8.0 Block enacting. Execution of transactions.
-        let enact_result = enact_verified(
-            block,
-            engine,
-            client.tracedb.read().tracing_enabled(),
-            db,
-            &parent,
-            last_hashes,
-            client.factories.clone(),
-            is_epoch_begin,
-            &mut chain.ancestry_with_metadata_iter(*header.parent_hash()),
-        );
-
-        let mut locked_block = match enact_result {
-            Ok(b) => b,
-            Err(e) => {
-                warn!(target: "client", "Block import failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
-                bail!(e);
-            }
-        };
-
-        // t_nb 7.6 Strip receipts for blocks before validate_receipts_transition,
-        // if the expected receipts root header does not match.
-        // (i.e. allow inconsistency in receipts outcome before the transition block)
-        if header.number() < engine.params().validate_receipts_transition
-            && header.receipts_root() != locked_block.header.receipts_root()
-        {
-            locked_block.strip_receipts_outcomes();
-        }
-
-        // t_nb 7.7 Final Verification. See if block that we created (executed) matches exactly with block that we received.
-        if let Err(e) = self
-            .verifier
-            .verify_block_final(&header, &locked_block.header)
-        {
-            warn!(target: "client", "Stage 5 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
-            bail!(e);
-        }
-
-        let pending = self.check_epoch_end_signal(
-            &header,
-            bytes,
-            &locked_block.receipts,
-            locked_block.state.db(),
-            client,
-        )?;
-
-        Ok((locked_block, pending))
-    }
-
-    /// Import a block with transaction receipts.
-    ///
-    /// The block is guaranteed to be the next best blocks in the
-    /// first block sequence. Does no sealing or transaction validation.
-    fn import_old_block(
-        &self,
-        unverified: Unverified,
-        receipts_bytes: &[u8],
-        db: &dyn KeyValueDB,
-        chain: &BlockChain,
-    ) -> EthcoreResult<()> {
-        let receipts = TypedReceipt::decode_rlp_list(&Rlp::new(receipts_bytes))
-            .unwrap_or_else(|e| panic!("Receipt bytes should be valid: {:?}", e));
-        let _import_lock = self.import_lock.lock();
-
-        if unverified.header.number() >= chain.best_block_header().number() {
-            panic!("Ancient block number is higher then best block number");
-        }
-
-        {
-            trace_time!("import_old_block");
-            // verify the block, passing the chain for updating the epoch verifier.
-            let mut rng = OsRng;
-            self.ancient_verifier
-                .verify(&mut rng, &unverified.header, &chain)?;
-
-            // Commit results
-            let mut batch = DBTransaction::new();
-            chain.insert_unordered_block(
-                &mut batch,
-                encoded::Block::new(unverified.bytes),
-                receipts,
-                None,
-                false,
-                true,
-            );
-            // Final commit to the DB
-            db.write_buffered(batch);
-            chain.commit();
-        }
-        db.flush().expect("DB flush failed.");
-        Ok(())
-    }
-
-    // NOTE: the header of the block passed here is not necessarily sealed, as
-    // it is for reconstructing the state transition.
-    //
-    // The header passed is from the original block data and is sealed.
-    // TODO: should return an error if ImportRoute is none, issue #9910
-    fn commit_block<B>(
-        &self,
-        block: B,
-        header: &Header,
-        block_data: encoded::Block,
-        pending: Option<PendingTransition>,
-        client: &Client,
-    ) -> ImportRoute
-    where
-        B: Drain,
-    {
-        let hash = &header.hash();
-        let number = header.number();
-        let parent = header.parent_hash();
-        let chain = client.chain.read();
-        let mut is_finalized = false;
-
-        // Commit results
-        let block = block.drain();
-        debug_assert_eq!(header.hash(), block_data.header_view().hash());
-
-        let mut batch = DBTransaction::new();
-
-        // t_nb 9.1 Gather all ancestry actions. (Used only by AuRa)
-        let ancestry_actions = self
-            .engine
-            .ancestry_actions(&header, &mut chain.ancestry_with_metadata_iter(*parent));
-
-        let receipts = block.receipts;
-        let traces = block.traces.drain();
-        let best_hash = chain.best_block_hash();
-
-        let new = ExtendedHeader {
-            header: header.clone(),
-            is_finalized,
-            parent_total_difficulty: chain
-                .block_details(&parent)
-                .expect("Parent block is in the database; qed")
-                .total_difficulty,
-        };
-
-        let best = {
-            let hash = best_hash;
-            let header = chain
-                .block_header_data(&hash)
-                .expect("Best block is in the database; qed")
-                .decode()
-                .expect("Stored block header is valid RLP; qed");
-            let details = chain
-                .block_details(&hash)
-                .expect("Best block is in the database; qed");
-
-            ExtendedHeader {
-                parent_total_difficulty: details.total_difficulty - *header.difficulty(),
-                is_finalized: details.is_finalized,
-                header: header,
-            }
-        };
-
-        // t_nb 9.2 calcuate route between current and latest block.
-        let route = chain.tree_route(best_hash, *parent).expect("forks are only kept when it has common ancestors; tree route from best to prospective's parent always exists; qed");
-
-        // t_nb 9.3 Check block total difficulty
-        let fork_choice = if route.is_from_route_finalized {
-            ForkChoice::Old
-        } else {
-            self.engine.fork_choice(&new, &best)
-        };
-
-        // t_nb 9.4 CHECK! I *think* this is fine, even if the state_root is equal to another
-        // already-imported block of the same number.
-        // TODO: Prove it with a test.
-        let mut state = block.state.drop().1;
-
-        // t_nb 9.5 check epoch end signal, potentially generating a proof on the current
-        // state. Write transition into db.
-        if let Some(pending) = pending {
-            chain.insert_pending_transition(&mut batch, header.hash(), pending);
-        }
-
-        // t_nb 9.6 push state to database Transaction. (It calls journal_under from JournalDB)
-        state
-            .journal_under(&mut batch, number, hash)
-            .expect("DB commit failed");
-
-        let finalized: Vec<_> = ancestry_actions
-            .into_iter()
-            .map(|ancestry_action| {
-                let AncestryAction::MarkFinalized(a) = ancestry_action;
-
-                if a != header.hash() {
-                    // t_nb 9.7 if there are finalized ancester, mark that chainge in block in db. (Used by AuRa)
-                    chain
-                        .mark_finalized(&mut batch, a)
-                        .expect("Engine's ancestry action must be known blocks; qed");
-                } else {
-                    // we're finalizing the current block
-                    is_finalized = true;
-                }
-
-                a
-            })
-            .collect();
-
-        // t_nb 9.8 insert block
-        let route = chain.insert_block(
-            &mut batch,
-            block_data,
-            receipts.clone(),
-            ExtrasInsert {
-                fork_choice: fork_choice,
-                is_finalized,
-            },
-        );
-
-        // t_nb 9.9 insert traces (if they are enabled)
-        client.tracedb.read().import(
-            &mut batch,
-            TraceImportRequest {
-                traces: traces.into(),
-                block_hash: hash.clone(),
-                block_number: number,
-                enacted: route.enacted.clone(),
-                retracted: route.retracted.len(),
-            },
-        );
-
-        let is_canon = route.enacted.last().map_or(false, |h| h == hash);
-
-        // t_nb 9.10 sync cache
-        state.sync_cache(&route.enacted, &route.retracted, is_canon);
-        // Final commit to the DB
-        // t_nb 9.11 Write Transaction to database (cached)
-        client.db.read().key_value().write_buffered(batch);
-        // t_nb 9.12 commit changed to become current greatest by applying pending insertion updates (Sync point)
-        chain.commit();
-
-        // t_nb 9.13 check epoch end. Related only to AuRa and it seems light engine
-        self.check_epoch_end(&header, &finalized, &chain, client);
-
-        // t_nb 9.14 update last hashes. They are build in step 7.5
-        client.update_last_hashes(&parent, hash);
-
-        // t_nb 9.15 prune ancient states
-        if let Err(e) = client.prune_ancient(state, &chain) {
-            warn!("Failed to prune ancient state data: {}", e);
-        }
-
-        route
-    }
-
-    // check for epoch end signal and write pending transition if it occurs.
-    // state for the given block must be available.
-    fn check_epoch_end_signal(
-        &self,
-        header: &Header,
-        block_bytes: &[u8],
-        receipts: &[TypedReceipt],
-        state_db: &StateDB,
-        client: &Client,
-    ) -> EthcoreResult<Option<PendingTransition>> {
-        use engines::EpochChange;
-
-        let hash = header.hash();
-        let auxiliary = ::machine::AuxiliaryData {
-            bytes: Some(block_bytes),
-            receipts: Some(&receipts),
-        };
-
-        match self.engine.signals_epoch_end(header, auxiliary) {
-            EpochChange::Yes(proof) => {
-                use engines::Proof;
-
-                let proof = match proof {
-                    Proof::Known(proof) => proof,
-                    Proof::WithState(with_state) => {
-                        let env_info = EnvInfo {
-                            number: header.number(),
-                            author: header.author().clone(),
-                            timestamp: header.timestamp(),
-                            difficulty: header.difficulty().clone(),
-                            last_hashes: client.build_last_hashes(header.parent_hash()),
-                            gas_used: U256::default(),
-                            gas_limit: u64::max_value().into(),
-                        };
-
-                        let call = move |addr, data| {
-                            let mut state_db = state_db.boxed_clone();
-                            let backend = ::state::backend::Proving::new(state_db.as_hash_db_mut());
-
-                            let transaction = client.contract_call_tx(
-                                BlockId::Hash(*header.parent_hash()),
-                                addr,
-                                data,
-                            );
-
-                            let mut state = State::from_existing(
-                                backend,
-                                header.state_root().clone(),
-                                self.engine.account_start_nonce(header.number()),
-                                client.factories.clone(),
-                            )
-                            .expect("state known to be available for just-imported block; qed");
-
-                            let options = TransactOptions::with_no_tracing().dont_check_nonce();
-                            let machine = self.engine.machine();
-                            let schedule = machine.schedule(env_info.number);
-                            let res = Executive::new(&mut state, &env_info, &machine, &schedule)
-                                .transact(&transaction, options);
-
-                            let res = match res {
-                                Err(e) => {
-                                    trace!(target: "client", "Proved call failed: {}", e);
-                                    Err(e.to_string())
-                                }
-                                Ok(res) => Ok((res.output, state.drop().1.extract_proof())),
-                            };
-
-                            res.map(|(output, proof)| {
-                                (output, proof.into_iter().map(|x| x.into_vec()).collect())
-                            })
-                        };
-
-                        match with_state.generate_proof(&call) {
-                            Ok(proof) => proof,
-                            Err(e) => {
-                                warn!(target: "client", "Failed to generate transition proof for block {}: {}", hash, e);
-                                warn!(target: "client", "Snapshots produced by this client may be incomplete");
-                                return Err(EngineError::FailedSystemCall(e).into());
-                            }
-                        }
-                    }
-                };
-
-                debug!(target: "client", "Block {} signals epoch end.", hash);
-
-                Ok(Some(PendingTransition { proof: proof }))
-            }
-            EpochChange::No => Ok(None),
-            EpochChange::Unsure(_) => {
-                warn!(target: "client", "Detected invalid engine implementation.");
-                warn!(target: "client", "Engine claims to require more block data, but everything provided.");
-                Err(EngineError::InvalidEngine.into())
-            }
-        }
-    }
-
-    // check for ending of epoch and write transition if it occurs.
-    fn check_epoch_end<'a>(
-        &self,
-        header: &'a Header,
-        finalized: &'a [H256],
-        chain: &BlockChain,
-        client: &Client,
-    ) {
-        let is_epoch_end = self.engine.is_epoch_end(
-            header,
-            finalized,
-            &(|hash| client.block_header_decoded(BlockId::Hash(hash))),
-            &(|hash| chain.get_pending_transition(hash)), // TODO: limit to current epoch.
-        );
-
-        if let Some(proof) = is_epoch_end {
-            debug!(target: "client", "Epoch transition at block {}", header.hash());
-
-            let mut batch = DBTransaction::new();
-            chain.insert_epoch_transition(
-                &mut batch,
-                header.number(),
-                EpochTransition {
-                    block_hash: header.hash(),
-                    block_number: header.number(),
-                    proof: proof,
-                },
-            );
-
-            // always write the batch directly since epoch transition proofs are
-            // fetched from a DB iterator and DB iterators are only available on
-            // flushed data.
-            client
-                .db
-                .read()
-                .key_value()
-                .write(batch)
-                .expect("DB flush failed");
-        }
-    }
+    pub exit_handler: Mutex<Option<Box<dyn Fn(String) + 'static + Send>>>,
 }
 
 impl Client {
@@ -945,7 +338,12 @@ impl Client {
             _ => true,
         };
 
-        let importer = Importer::new(&config, engine.clone(), message_channel.clone(), miner)?;
+        let importer = super::importer::Importer::new(
+            &config,
+            engine.clone(),
+            message_channel.clone(),
+            miner,
+        )?;
 
         let registrar_address = engine
             .additional_params()
@@ -1069,6 +467,47 @@ impl Client {
         Ok(client)
     }
 
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::SeqCst)
+    }
+
+    pub fn disable(&self) {
+        self.enabled.store(false, Ordering::SeqCst);
+    }
+
+    pub fn engine(&self) -> Arc<dyn EthEngine> {
+        self.engine.clone()
+    }
+
+    pub fn mode(&self) -> Mode {
+        let r = self.mode.lock().clone().into();
+        trace!(target: "mode", "Asked for mode = {:?}. returning {:?}", &*self.mode.lock(), r);
+        r
+    }
+
+    pub fn set_mode(&self, new_mode: Mode) {
+        trace!(target: "mode", "Client::set_mode({:?})", new_mode);
+        if !self.enabled() {
+            return;
+        }
+        {
+            let mut mode = self.mode.lock();
+            *mode = new_mode.clone().into();
+            trace!(target: "mode", "Mode now {:?}", &*mode);
+            if let Some(ref mut f) = *self.on_user_defaults_change.lock() {
+                trace!(target: "mode", "Making callback...");
+                f(Some((&*mode).clone()))
+            }
+        }
+        match new_mode {
+            Mode::Active => self.wake_up(),
+            Mode::Off => self.sleep(true),
+            _ => {
+                (*self.sleep_state.lock()).last_activity = Some(Instant::now());
+            }
+        }
+    }
+
     /// signals shutdown of application. We do cleanup here.
     pub fn shutdown(&self) {
         let mut abe = self.queued_ancient_blocks_executer.lock();
@@ -1095,12 +534,7 @@ impl Client {
         self.notify.write().push(Arc::downgrade(&target));
     }
 
-    /// Returns engine reference.
-    pub fn engine(&self) -> &dyn EthEngine {
-        &*self.engine
-    }
-
-    fn notify<F>(&self, f: F)
+    pub fn notify<F>(&self, f: F)
     where
         F: Fn(&dyn ChainNotify),
     {
@@ -1147,7 +581,7 @@ impl Client {
         })
     }
 
-    fn build_last_hashes(&self, parent_hash: &H256) -> Arc<LastHashes> {
+    pub fn build_last_hashes(&self, parent_hash: &H256) -> Arc<LastHashes> {
         {
             let hashes = self.last_hashes.read();
             if hashes.front().map_or(false, |h| h == parent_hash) {
@@ -1197,7 +631,7 @@ impl Client {
     }
 
     // t_nb 9.15 prune ancient states until below the memory limit or only the minimum amount remain.
-    fn prune_ancient(
+    pub fn prune_ancient(
         &self,
         mut state_db: StateDB,
         chain: &BlockChain,
@@ -1218,7 +652,7 @@ impl Client {
             }
             match state_db.journal_db().earliest_era() {
                 Some(earliest_era) if earliest_era + self.history <= latest_era => {
-                    let freeze_at = self.snapshotting_at.load(AtomicOrdering::SeqCst);
+                    let freeze_at = self.snapshotting_at.load(Ordering::SeqCst);
                     if freeze_at > 0 && freeze_at == earliest_era {
                         // Note: journal_db().mem_used() can be used for a more accurate memory
                         // consumption measurement but it can be expensive so sticking with the
@@ -1248,7 +682,7 @@ impl Client {
     }
 
     // t_nb 9.14 update last hashes. They are build in step 7.5
-    fn update_last_hashes(&self, parent: &H256, hash: &H256) {
+    pub fn update_last_hashes(&self, parent: &H256, hash: &H256) {
         let mut hashes = self.last_hashes.write();
         if hashes.front().map_or(false, |h| h == parent) {
             if hashes.len() > 255 {
@@ -1460,11 +894,11 @@ impl Client {
             .snapshot_components()
             .ok_or(snapshot::Error::SnapshotsUnsupported)?;
         self.snapshotting_at
-            .store(snapshot_block_number, AtomicOrdering::SeqCst);
+            .store(snapshot_block_number, Ordering::SeqCst);
         {
             scopeguard::defer! {{
                 info!(target: "snapshot", "Re-enabling pruning.");
-                self.snapshotting_at.store(0, AtomicOrdering::SeqCst)
+                self.snapshotting_at.store(0, Ordering::SeqCst)
             }};
             snapshot::take_snapshot(
                 chunker,
@@ -1484,7 +918,7 @@ impl Client {
         self.history
     }
 
-    fn block_hash(chain: &BlockChain, id: BlockId) -> Option<H256> {
+    pub fn block_hash(chain: &BlockChain, id: BlockId) -> Option<H256> {
         match id {
             BlockId::Hash(hash) => Some(hash),
             BlockId::Number(number) => chain.block_hash(number),
@@ -1493,7 +927,7 @@ impl Client {
         }
     }
 
-    fn transaction_address(&self, id: TransactionId) -> Option<TransactionAddress> {
+    pub fn transaction_address(&self, id: TransactionId) -> Option<TransactionAddress> {
         match id {
             TransactionId::Hash(ref hash) => self.chain.read().transaction_address(hash),
             TransactionId::Location(id, index) => {
@@ -1506,18 +940,18 @@ impl Client {
     }
 
     fn wake_up(&self) {
-        if !self.liveness.load(AtomicOrdering::SeqCst) {
-            self.liveness.store(true, AtomicOrdering::SeqCst);
+        if !self.liveness.load(Ordering::SeqCst) {
+            self.liveness.store(true, Ordering::SeqCst);
             self.notify(|n| n.start());
             info!(target: "mode", "wake_up: Waking.");
         }
     }
 
     fn sleep(&self, force: bool) {
-        if self.liveness.load(AtomicOrdering::SeqCst) {
+        if self.liveness.load(Ordering::SeqCst) {
             // only sleep if the import queue is mostly empty.
             if force || (self.queue_info().total_queue_size() <= MAX_QUEUE_SIZE_TO_SLEEP_ON) {
-                self.liveness.store(false, AtomicOrdering::SeqCst);
+                self.liveness.store(false, Ordering::SeqCst);
                 self.notify(|n| n.stop());
                 info!(target: "mode", "sleep: Sleeping.");
             } else {
@@ -1530,7 +964,7 @@ impl Client {
 
     // transaction for calling contracts from services like engine.
     // from the null sender, with 50M gas.
-    fn contract_call_tx(
+    pub fn contract_call_tx(
         &self,
         block_id: BlockId,
         address: Address,
@@ -1550,7 +984,7 @@ impl Client {
         .fake_sign(from)
     }
 
-    fn do_virtual_call(
+    pub fn do_virtual_call(
         machine: &::machine::EthereumMachine,
         env_info: &EnvInfo,
         state: &mut State<StateDB>,
@@ -1624,7 +1058,7 @@ impl Client {
         }
     }
 
-    fn block_number_ref(&self, id: &BlockId) -> Option<BlockNumber> {
+    pub fn block_number_ref(&self, id: &BlockId) -> Option<BlockNumber> {
         match *id {
             BlockId::Number(number) => Some(number),
             BlockId::Hash(ref hash) => self.chain.read().block_number(hash),
@@ -1637,7 +1071,7 @@ impl Client {
     ///
     /// This method optimizes access patterns for latest block header
     /// to avoid excessive RLP encoding, decoding and hashing.
-    fn block_header_decoded(&self, id: BlockId) -> Option<Header> {
+    pub fn block_header_decoded(&self, id: BlockId) -> Option<Header> {
         match id {
             BlockId::Latest => Some(self.chain.read().best_block_header()),
             BlockId::Hash(ref hash) if hash == &self.chain.read().best_block_hash() => {
@@ -1768,46 +1202,6 @@ impl Balance for Client {
 
 impl AccountData for Client {}
 
-impl ChainInfo for Client {
-    fn chain_info(&self) -> BlockChainInfo {
-        let mut chain_info = self.chain.read().chain_info();
-        chain_info.pending_total_difficulty =
-            chain_info.total_difficulty + self.importer.block_queue.total_difficulty();
-        chain_info
-    }
-}
-
-impl BlockInfo for Client {
-    fn block_header(&self, id: BlockId) -> Option<encoded::Header> {
-        let chain = self.chain.read();
-
-        Self::block_hash(&chain, id).and_then(|hash| chain.block_header_data(&hash))
-    }
-
-    fn best_block_header(&self) -> Header {
-        self.chain.read().best_block_header()
-    }
-
-    fn block(&self, id: BlockId) -> Option<encoded::Block> {
-        let chain = self.chain.read();
-
-        Self::block_hash(&chain, id).and_then(|hash| chain.block(&hash))
-    }
-
-    fn code_hash(&self, address: &Address, id: BlockId) -> Option<H256> {
-        self.state_at(id)
-            .and_then(|s| s.code_hash(address).unwrap_or(None))
-    }
-}
-
-impl TransactionInfo for Client {
-    fn transaction_block(&self, id: TransactionId) -> Option<H256> {
-        self.transaction_address(id).map(|addr| addr.block_hash)
-    }
-}
-
-impl BlockChainTrait for Client {}
-
 impl RegistryInfo for Client {
     fn registry_address(&self, name: String, block: BlockId) -> Option<Address> {
         use ethabi::FunctionOutputDecoder;
@@ -1916,902 +1310,9 @@ impl Drop for Client {
     }
 }
 
-impl Call for Client {
-    type State = State<::state_db::StateDB>;
-
-    fn call(
-        &self,
-        transaction: &SignedTransaction,
-        analytics: CallAnalytics,
-        state: &mut Self::State,
-        header: &Header,
-    ) -> Result<Executed, CallError> {
-        let env_info = EnvInfo {
-            number: header.number(),
-            author: header.author().clone(),
-            timestamp: header.timestamp(),
-            difficulty: header.difficulty().clone(),
-            last_hashes: self.build_last_hashes(header.parent_hash()),
-            gas_used: U256::default(),
-            gas_limit: U256::max_value(),
-        };
-        let machine = self.engine.machine();
-
-        Self::do_virtual_call(&machine, &env_info, state, transaction, analytics)
-    }
-
-    fn call_many(
-        &self,
-        transactions: &[(SignedTransaction, CallAnalytics)],
-        state: &mut Self::State,
-        header: &Header,
-    ) -> Result<Vec<Executed>, CallError> {
-        let mut env_info = EnvInfo {
-            number: header.number(),
-            author: header.author().clone(),
-            timestamp: header.timestamp(),
-            difficulty: header.difficulty().clone(),
-            last_hashes: self.build_last_hashes(header.parent_hash()),
-            gas_used: U256::default(),
-            gas_limit: U256::max_value(),
-        };
-
-        let mut results = Vec::with_capacity(transactions.len());
-        let machine = self.engine.machine();
-
-        for &(ref t, analytics) in transactions {
-            let ret = Self::do_virtual_call(machine, &env_info, state, t, analytics)?;
-            env_info.gas_used = ret.cumulative_gas_used;
-            results.push(ret);
-        }
-
-        Ok(results)
-    }
-
-    fn estimate_gas(
-        &self,
-        t: &SignedTransaction,
-        state: &Self::State,
-        header: &Header,
-    ) -> Result<U256, CallError> {
-        let (mut upper, max_upper, env_info) = {
-            let init = *header.gas_limit();
-            let max = init * U256::from(10);
-
-            let env_info = EnvInfo {
-                number: header.number(),
-                author: header.author().clone(),
-                timestamp: header.timestamp(),
-                difficulty: header.difficulty().clone(),
-                last_hashes: self.build_last_hashes(header.parent_hash()),
-                gas_used: U256::default(),
-                gas_limit: max,
-            };
-
-            (init, max, env_info)
-        };
-
-        let sender = t.sender();
-        let options = || TransactOptions::with_tracing().dont_check_nonce();
-
-        let exec = |gas| {
-            let mut tx = t.as_unsigned().clone();
-            tx.tx_mut().gas = gas;
-            let tx = tx.fake_sign(sender);
-
-            let mut clone = state.clone();
-            let machine = self.engine.machine();
-            let schedule = machine.schedule(env_info.number);
-            Executive::new(&mut clone, &env_info, &machine, &schedule)
-                .transact_virtual(&tx, options())
-        };
-
-        let cond = |gas| exec(gas).ok().map_or(false, |r| r.exception.is_none());
-
-        if !cond(upper) {
-            upper = max_upper;
-            match exec(upper) {
-                Ok(v) => {
-                    if let Some(exception) = v.exception {
-                        return Err(CallError::Exceptional(exception));
-                    }
-                }
-                Err(_e) => {
-                    trace!(target: "estimate_gas", "estimate_gas failed with {}", upper);
-                    let err = ExecutionError::Internal(format!(
-                        "Requires higher than upper limit of {}",
-                        upper
-                    ));
-                    return Err(err.into());
-                }
-            }
-        }
-        let lower = t
-            .tx()
-            .gas_required(&self.engine.schedule(env_info.number))
-            .into();
-        if cond(lower) {
-            trace!(target: "estimate_gas", "estimate_gas succeeded with {}", lower);
-            return Ok(lower);
-        }
-
-        /// Find transition point between `lower` and `upper` where `cond` changes from `false` to `true`.
-        /// Returns the lowest value between `lower` and `upper` for which `cond` returns true.
-        /// We assert: `cond(lower) = false`, `cond(upper) = true`
-        fn binary_chop<F, E>(mut lower: U256, mut upper: U256, mut cond: F) -> Result<U256, E>
-        where
-            F: FnMut(U256) -> bool,
-        {
-            while upper - lower > 1.into() {
-                let mid = (lower + upper) / 2;
-                trace!(target: "estimate_gas", "{} .. {} .. {}", lower, mid, upper);
-                let c = cond(mid);
-                match c {
-                    true => upper = mid,
-                    false => lower = mid,
-                };
-                trace!(target: "estimate_gas", "{} => {} .. {}", c, lower, upper);
-            }
-            Ok(upper)
-        }
-
-        // binary chop to non-excepting call with gas somewhere between 21000 and block gas limit
-        trace!(target: "estimate_gas", "estimate_gas chopping {} .. {}", lower, upper);
-        binary_chop(lower, upper, cond)
-    }
-}
-
-impl EngineInfo for Client {
-    fn engine(&self) -> &dyn EthEngine {
-        Client::engine(self)
-    }
-}
-
 impl BadBlocks for Client {
     fn bad_blocks(&self) -> Vec<(Unverified, String)> {
         self.importer.bad_blocks.bad_blocks()
-    }
-}
-
-impl BlockChainClient for Client {
-    fn replay(&self, id: TransactionId, analytics: CallAnalytics) -> Result<Executed, CallError> {
-        let address = self
-            .transaction_address(id)
-            .ok_or(CallError::TransactionNotFound)?;
-        let block = BlockId::Hash(address.block_hash);
-
-        const PROOF: &'static str =
-            "The transaction address contains a valid index within block; qed";
-        Ok(self
-            .replay_block_transactions(block, analytics)?
-            .nth(address.index)
-            .expect(PROOF)
-            .1)
-    }
-
-    fn replay_block_transactions(
-        &self,
-        block: BlockId,
-        analytics: CallAnalytics,
-    ) -> Result<Box<dyn Iterator<Item = (H256, Executed)>>, CallError> {
-        let mut env_info = self.env_info(block).ok_or(CallError::StatePruned)?;
-        let body = self.block_body(block).ok_or(CallError::StatePruned)?;
-        let mut state = self
-            .state_at_beginning(block)
-            .ok_or(CallError::StatePruned)?;
-        let txs = body.transactions();
-        let engine = self.engine.clone();
-
-        const PROOF: &'static str =
-            "Transactions fetched from blockchain; blockchain transactions are valid; qed";
-        const EXECUTE_PROOF: &'static str = "Transaction replayed; qed";
-
-        Ok(Box::new(txs.into_iter().map(move |t| {
-            let transaction_hash = t.hash();
-            let t = SignedTransaction::new(t).expect(PROOF);
-            let machine = engine.machine();
-            let x = Self::do_virtual_call(machine, &env_info, &mut state, &t, analytics)
-                .expect(EXECUTE_PROOF);
-            env_info.gas_used = env_info.gas_used + x.gas_used;
-            (transaction_hash, x)
-        })))
-    }
-
-    fn mode(&self) -> Mode {
-        let r = self.mode.lock().clone().into();
-        trace!(target: "mode", "Asked for mode = {:?}. returning {:?}", &*self.mode.lock(), r);
-        r
-    }
-
-    fn disable(&self) {
-        self.set_mode(Mode::Off);
-        self.enabled.store(false, AtomicOrdering::SeqCst);
-        self.clear_queue();
-    }
-
-    fn set_mode(&self, new_mode: Mode) {
-        trace!(target: "mode", "Client::set_mode({:?})", new_mode);
-        if !self.enabled.load(AtomicOrdering::SeqCst) {
-            return;
-        }
-        {
-            let mut mode = self.mode.lock();
-            *mode = new_mode.clone().into();
-            trace!(target: "mode", "Mode now {:?}", &*mode);
-            if let Some(ref mut f) = *self.on_user_defaults_change.lock() {
-                trace!(target: "mode", "Making callback...");
-                f(Some((&*mode).clone()))
-            }
-        }
-        match new_mode {
-            Mode::Active => self.wake_up(),
-            Mode::Off => self.sleep(true),
-            _ => {
-                (*self.sleep_state.lock()).last_activity = Some(Instant::now());
-            }
-        }
-    }
-
-    fn spec_name(&self) -> String {
-        self.config.spec_name.clone()
-    }
-
-    fn is_canon(&self, hash: &H256) -> bool {
-        self.chain.read().is_canon(hash)
-    }
-
-    fn set_spec_name(&self, new_spec_name: String) -> Result<(), ()> {
-        trace!(target: "mode", "Client::set_spec_name({:?})", new_spec_name);
-        if !self.enabled.load(AtomicOrdering::SeqCst) {
-            return Err(());
-        }
-        if let Some(ref h) = *self.exit_handler.lock() {
-            (*h)(new_spec_name);
-            Ok(())
-        } else {
-            warn!("Not hypervised; cannot change chain.");
-            Err(())
-        }
-    }
-
-    fn block_number(&self, id: BlockId) -> Option<BlockNumber> {
-        self.block_number_ref(&id)
-    }
-
-    fn block_body(&self, id: BlockId) -> Option<encoded::Body> {
-        let chain = self.chain.read();
-
-        Self::block_hash(&chain, id).and_then(|hash| chain.block_body(&hash))
-    }
-
-    fn block_status(&self, id: BlockId) -> BlockStatus {
-        let chain = self.chain.read();
-        match Self::block_hash(&chain, id) {
-            Some(ref hash) if chain.is_known(hash) => BlockStatus::InChain,
-            Some(hash) => self.importer.block_queue.status(&hash).into(),
-            None => BlockStatus::Unknown,
-        }
-    }
-
-    fn is_processing_fork(&self) -> bool {
-        let chain = self.chain.read();
-        self.importer
-            .block_queue
-            .is_processing_fork(&chain.best_block_hash(), &chain)
-    }
-
-    fn block_total_difficulty(&self, id: BlockId) -> Option<U256> {
-        let chain = self.chain.read();
-
-        Self::block_hash(&chain, id)
-            .and_then(|hash| chain.block_details(&hash))
-            .map(|d| d.total_difficulty)
-    }
-
-    fn storage_root(&self, address: &Address, id: BlockId) -> Option<H256> {
-        self.state_at(id)
-            .and_then(|s| s.storage_root(address).ok())
-            .and_then(|x| x)
-    }
-
-    fn block_hash(&self, id: BlockId) -> Option<H256> {
-        let chain = self.chain.read();
-        Self::block_hash(&chain, id)
-    }
-
-    fn code(&self, address: &Address, state: StateOrBlock) -> Option<Option<Bytes>> {
-        let result = match state {
-            StateOrBlock::State(s) => s.code(address).ok(),
-            StateOrBlock::Block(id) => self.state_at(id).and_then(|s| s.code(address).ok()),
-        };
-
-        // Converting from `Option<Option<Arc<Bytes>>>` to `Option<Option<Bytes>>`
-        result.map(|c| c.map(|c| (&*c).clone()))
-    }
-
-    fn storage_at(&self, address: &Address, position: &H256, state: StateOrBlock) -> Option<H256> {
-        match state {
-            StateOrBlock::State(s) => s.storage_at(address, position).ok(),
-            StateOrBlock::Block(id) => self
-                .state_at(id)
-                .and_then(|s| s.storage_at(address, position).ok()),
-        }
-    }
-
-    fn list_accounts(
-        &self,
-        id: BlockId,
-        after: Option<&Address>,
-        count: u64,
-    ) -> Option<Vec<Address>> {
-        if !self.factories.trie.is_fat() {
-            trace!(target: "fatdb", "list_accounts: Not a fat DB");
-            return None;
-        }
-
-        let state = match self.state_at(id) {
-            Some(state) => state,
-            _ => return None,
-        };
-
-        let (root, db) = state.drop();
-        let db = &db.as_hash_db();
-        let trie = match self.factories.trie.readonly(db, &root) {
-            Ok(trie) => trie,
-            _ => {
-                trace!(target: "fatdb", "list_accounts: Couldn't open the DB");
-                return None;
-            }
-        };
-
-        let mut iter = match trie.iter() {
-            Ok(iter) => iter,
-            _ => return None,
-        };
-
-        if let Some(after) = after {
-            if let Err(e) = iter.seek(after.as_bytes()) {
-                trace!(target: "fatdb", "list_accounts: Couldn't seek the DB: {:?}", e);
-            } else {
-                // Position the iterator after the `after` element
-                iter.next();
-            }
-        }
-
-        let accounts = iter
-            .filter_map(|item| item.ok().map(|(addr, _)| Address::from_slice(&addr)))
-            .take(count as usize)
-            .collect();
-
-        Some(accounts)
-    }
-
-    fn list_storage(
-        &self,
-        id: BlockId,
-        account: &Address,
-        after: Option<&H256>,
-        count: u64,
-    ) -> Option<Vec<H256>> {
-        if !self.factories.trie.is_fat() {
-            trace!(target: "fatdb", "list_storage: Not a fat DB");
-            return None;
-        }
-
-        let state = match self.state_at(id) {
-            Some(state) => state,
-            _ => return None,
-        };
-
-        let root = match state.storage_root(account) {
-            Ok(Some(root)) => root,
-            _ => return None,
-        };
-
-        let (_, db) = state.drop();
-        let account_db = &self
-            .factories
-            .accountdb
-            .readonly(db.as_hash_db(), keccak(account));
-        let account_db = &account_db.as_hash_db();
-        let trie = match self.factories.trie.readonly(account_db, &root) {
-            Ok(trie) => trie,
-            _ => {
-                trace!(target: "fatdb", "list_storage: Couldn't open the DB");
-                return None;
-            }
-        };
-
-        let mut iter = match trie.iter() {
-            Ok(iter) => iter,
-            _ => return None,
-        };
-
-        if let Some(after) = after {
-            if let Err(e) = iter.seek(after.as_bytes()) {
-                trace!(target: "fatdb", "list_storage: Couldn't seek the DB: {:?}", e);
-            } else {
-                // Position the iterator after the `after` element
-                iter.next();
-            }
-        }
-
-        let keys = iter
-            .filter_map(|item| item.ok().map(|(key, _)| H256::from_slice(&key)))
-            .take(count as usize)
-            .collect();
-
-        Some(keys)
-    }
-
-    fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction> {
-        self.transaction_address(id)
-            .and_then(|address| self.chain.read().transaction(&address))
-    }
-
-    fn uncle(&self, id: UncleId) -> Option<encoded::Header> {
-        let index = id.position;
-        self.block_body(id.block)
-            .and_then(|body| body.view().uncle_rlp_at(index))
-            .map(encoded::Header::new)
-    }
-
-    fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt> {
-        // NOTE Don't use block_receipts here for performance reasons
-        let address = self.transaction_address(id)?;
-        let hash = address.block_hash;
-        let chain = self.chain.read();
-        let number = chain.block_number(&hash)?;
-        let body = chain.block_body(&hash)?;
-        let mut receipts = chain.block_receipts(&hash)?.receipts;
-        receipts.truncate(address.index + 1);
-
-        let transaction = body
-            .view()
-            .localized_transaction_at(&hash, number, address.index)?;
-        let receipt = receipts.pop()?;
-        let gas_used = receipts.last().map_or_else(|| 0.into(), |r| r.gas_used);
-        let no_of_logs = receipts
-            .into_iter()
-            .map(|receipt| receipt.logs.len())
-            .sum::<usize>();
-
-        let receipt = transaction_receipt(
-            self.engine().machine(),
-            transaction,
-            receipt,
-            gas_used,
-            no_of_logs,
-        );
-        Some(receipt)
-    }
-
-    fn localized_block_receipts(&self, id: BlockId) -> Option<Vec<LocalizedReceipt>> {
-        let hash = self.block_hash(id)?;
-
-        let chain = self.chain.read();
-        let receipts = chain.block_receipts(&hash)?;
-        let number = chain.block_number(&hash)?;
-        let body = chain.block_body(&hash)?;
-        let engine = self.engine.clone();
-
-        let mut gas_used = 0.into();
-        let mut no_of_logs = 0;
-
-        Some(
-            body.view()
-                .localized_transactions(&hash, number)
-                .into_iter()
-                .zip(receipts.receipts)
-                .map(move |(transaction, receipt)| {
-                    let result = transaction_receipt(
-                        engine.machine(),
-                        transaction,
-                        receipt,
-                        gas_used,
-                        no_of_logs,
-                    );
-                    gas_used = result.cumulative_gas_used;
-                    no_of_logs += result.logs.len();
-                    result
-                })
-                .collect(),
-        )
-    }
-
-    fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {
-        let chain = self.chain.read();
-        match chain.is_known(from) && chain.is_known(to) {
-            true => chain.tree_route(from.clone(), to.clone()),
-            false => None,
-        }
-    }
-
-    fn find_uncles(&self, hash: &H256) -> Option<Vec<H256>> {
-        self.chain.read().find_uncle_hashes(hash, MAX_UNCLE_AGE)
-    }
-
-    fn block_receipts(&self, hash: &H256) -> Option<BlockReceipts> {
-        self.chain.read().block_receipts(hash)
-    }
-
-    fn queue_info(&self) -> BlockQueueInfo {
-        self.importer.block_queue.queue_info()
-    }
-
-    fn is_queue_empty(&self) -> bool {
-        self.importer.block_queue.is_empty()
-    }
-
-    fn clear_queue(&self) {
-        self.importer.block_queue.clear();
-    }
-
-    fn additional_params(&self) -> BTreeMap<String, String> {
-        self.engine.additional_params().into_iter().collect()
-    }
-
-    fn logs(&self, filter: Filter) -> Result<Vec<LocalizedLogEntry>, BlockId> {
-        let chain = self.chain.read();
-
-        // First, check whether `filter.from_block` and `filter.to_block` is on the canon chain. If so, we can use the
-        // optimized version.
-        let is_canon = |id| {
-            match id {
-                // If it is referred by number, then it is always on the canon chain.
-                &BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) => true,
-                // If it is referred by hash, we see whether a hash -> number -> hash conversion gives us the same
-                // result.
-                &BlockId::Hash(ref hash) => chain.is_canon(hash),
-            }
-        };
-
-        let blocks = if is_canon(&filter.from_block) && is_canon(&filter.to_block) {
-            // If we are on the canon chain, use bloom filter to fetch required hashes.
-            //
-            // If we are sure the block does not exist (where val > best_block_number), then return error. Note that we
-            // don't need to care about pending blocks here because RPC query sets pending back to latest (or handled
-            // pending logs themselves).
-            let from = match self.block_number_ref(&filter.from_block) {
-                Some(val) if val <= chain.best_block_number() => val,
-                _ => return Err(filter.from_block.clone()),
-            };
-            let to = match self.block_number_ref(&filter.to_block) {
-                Some(val) if val <= chain.best_block_number() => val,
-                _ => return Err(filter.to_block.clone()),
-            };
-
-            // If from is greater than to, then the current bloom filter behavior is to just return empty
-            // result. There's no point to continue here.
-            if from > to {
-                return Err(filter.to_block.clone());
-            }
-
-            chain
-                .blocks_with_bloom(&filter.bloom_possibilities(), from, to)
-                .into_iter()
-                .filter_map(|n| chain.block_hash(n))
-                .collect::<Vec<H256>>()
-        } else {
-            // Otherwise, we use a slower version that finds a link between from_block and to_block.
-            let from_hash = Self::block_hash(&chain, filter.from_block)
-                .ok_or_else(|| filter.from_block.clone())?;
-            let from_number = chain
-                .block_number(&from_hash)
-                .ok_or_else(|| BlockId::Hash(from_hash))?;
-            let to_hash =
-                Self::block_hash(&chain, filter.to_block).ok_or_else(|| filter.to_block.clone())?;
-
-            let blooms = filter.bloom_possibilities();
-            let bloom_match = |header: &encoded::Header| {
-                blooms
-                    .iter()
-                    .any(|bloom| header.log_bloom().contains_bloom(bloom))
-            };
-
-            let (blocks, last_hash) = {
-                let mut blocks = Vec::new();
-                let mut current_hash = to_hash;
-
-                loop {
-                    let header = chain
-                        .block_header_data(&current_hash)
-                        .ok_or_else(|| BlockId::Hash(current_hash))?;
-                    if bloom_match(&header) {
-                        blocks.push(current_hash);
-                    }
-
-                    // Stop if `from` block is reached.
-                    if header.number() <= from_number {
-                        break;
-                    }
-                    current_hash = header.parent_hash();
-                }
-
-                blocks.reverse();
-                (blocks, current_hash)
-            };
-
-            // Check if we've actually reached the expected `from` block.
-            if last_hash != from_hash || blocks.is_empty() {
-                // In this case, from_hash is the cause (for not matching last_hash).
-                return Err(BlockId::Hash(from_hash));
-            }
-
-            blocks
-        };
-
-        Ok(chain.logs(blocks, |entry| filter.matches(entry), filter.limit))
-    }
-
-    fn filter_traces(&self, filter: TraceFilter) -> Option<Vec<LocalizedTrace>> {
-        if !self.tracedb.read().tracing_enabled() {
-            return None;
-        }
-
-        let start = self.block_number(filter.range.start)?;
-        let end = self.block_number(filter.range.end)?;
-
-        let db_filter = trace::Filter {
-            range: start as usize..end as usize,
-            from_address: filter.from_address.into(),
-            to_address: filter.to_address.into(),
-        };
-
-        let traces = self
-            .tracedb
-            .read()
-            .filter(&db_filter)
-            .into_iter()
-            .skip(filter.after.unwrap_or(0))
-            .take(filter.count.unwrap_or(usize::max_value()))
-            .collect();
-        Some(traces)
-    }
-
-    fn trace(&self, trace: TraceId) -> Option<LocalizedTrace> {
-        if !self.tracedb.read().tracing_enabled() {
-            return None;
-        }
-
-        let trace_address = trace.address;
-        self.transaction_address(trace.transaction)
-            .and_then(|tx_address| {
-                self.block_number(BlockId::Hash(tx_address.block_hash))
-                    .and_then(|number| {
-                        self.tracedb
-                            .read()
-                            .trace(number, tx_address.index, trace_address)
-                    })
-            })
-    }
-
-    fn transaction_traces(&self, transaction: TransactionId) -> Option<Vec<LocalizedTrace>> {
-        if !self.tracedb.read().tracing_enabled() {
-            return None;
-        }
-
-        self.transaction_address(transaction)
-            .and_then(|tx_address| {
-                self.block_number(BlockId::Hash(tx_address.block_hash))
-                    .and_then(|number| {
-                        self.tracedb
-                            .read()
-                            .transaction_traces(number, tx_address.index)
-                    })
-            })
-    }
-
-    fn block_traces(&self, block: BlockId) -> Option<Vec<LocalizedTrace>> {
-        if !self.tracedb.read().tracing_enabled() {
-            return None;
-        }
-
-        self.block_number(block)
-            .and_then(|number| self.tracedb.read().block_traces(number))
-    }
-
-    fn last_hashes(&self) -> LastHashes {
-        (*self.build_last_hashes(&self.chain.read().best_block_hash())).clone()
-    }
-
-    fn transactions_to_propagate(&self) -> Vec<Arc<VerifiedTransaction>> {
-        const PROPAGATE_FOR_BLOCKS: u32 = 4;
-        const MIN_TX_TO_PROPAGATE: usize = 256;
-
-        let block_gas_limit = *self.best_block_header().gas_limit();
-        let min_tx_gas: U256 = self.latest_schedule().tx_gas.into();
-
-        let max_len = if min_tx_gas.is_zero() {
-            usize::max_value()
-        } else {
-            cmp::max(
-                MIN_TX_TO_PROPAGATE,
-                cmp::min(
-                    (block_gas_limit / min_tx_gas) * PROPAGATE_FOR_BLOCKS,
-                    // never more than usize
-                    usize::max_value().into(),
-                )
-                .as_u64() as usize,
-            )
-        };
-        self.importer
-            .miner
-            .ready_transactions(self, max_len, ::miner::PendingOrdering::Priority)
-    }
-
-    fn signing_chain_id(&self) -> Option<u64> {
-        self.engine.signing_chain_id(&self.latest_env_info())
-    }
-
-    fn block_extra_info(&self, id: BlockId) -> Option<BTreeMap<String, String>> {
-        self.block_header_decoded(id)
-            .map(|header| self.engine.extra_info(&header))
-    }
-
-    fn uncle_extra_info(&self, id: UncleId) -> Option<BTreeMap<String, String>> {
-        self.uncle(id)
-            .and_then(|h| h.decode().map(|dh| self.engine.extra_info(&dh)).ok())
-    }
-
-    fn pruning_info(&self) -> PruningInfo {
-        PruningInfo {
-            earliest_chain: self.chain.read().first_block_number().unwrap_or(1),
-            earliest_state: self
-                .state_db
-                .read()
-                .journal_db()
-                .earliest_era()
-                .unwrap_or(0),
-        }
-    }
-
-    fn create_transaction(
-        &self,
-        TransactionRequest {
-            action,
-            data,
-            gas,
-            gas_price,
-            nonce,
-        }: TransactionRequest,
-    ) -> Result<SignedTransaction, transaction::Error> {
-        let authoring_params = self.importer.miner.authoring_params();
-        let service_transaction_checker = self.importer.miner.service_transaction_checker();
-        let gas_price = if let Some(checker) = service_transaction_checker {
-            match checker.check_address(self, authoring_params.author) {
-                Ok(true) => U256::zero(),
-                _ => gas_price.unwrap_or_else(|| self.importer.miner.sensible_gas_price()),
-            }
-        } else {
-            self.importer.miner.sensible_gas_price()
-        };
-        let transaction = TypedTransaction::Legacy(transaction::Transaction {
-            nonce: nonce.unwrap_or_else(|| self.latest_nonce(&authoring_params.author)),
-            action,
-            gas: gas.unwrap_or_else(|| self.importer.miner.sensible_gas_limit()),
-            gas_price,
-            value: U256::zero(),
-            data,
-        });
-        let chain_id = self.engine.signing_chain_id(&self.latest_env_info());
-        let signature = self
-            .engine
-            .sign(transaction.signature_hash(chain_id))
-            .map_err(|e| transaction::Error::InvalidSignature(e.to_string()))?;
-        Ok(SignedTransaction::new(
-            transaction.with_signature(signature, chain_id),
-        )?)
-    }
-
-    fn transact(&self, tx_request: TransactionRequest) -> Result<(), transaction::Error> {
-        let signed = self.create_transaction(tx_request)?;
-        self.importer
-            .miner
-            .import_own_transaction(self, signed.into())
-    }
-
-    fn registrar_address(&self) -> Option<Address> {
-        self.registrar_address.clone()
-    }
-}
-
-impl IoClient for Client {
-    fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: usize) {
-        trace_time!("queue_transactions");
-        let len = transactions.len();
-        self.queue_transactions
-            .queue(&self.io_channel.read(), len, move |client| {
-                trace_time!("import_queued_transactions");
-                let best_block_number = client.best_block_header().number();
-                let txs: Vec<UnverifiedTransaction> = transactions
-                    .iter()
-                    .filter_map(|bytes| {
-                        client
-                            .engine
-                            .decode_transaction(bytes, best_block_number)
-                            .ok()
-                    })
-                    .collect();
-
-                client.notify(|notify| {
-                    notify.transactions_received(&txs, peer_id);
-                });
-
-                client
-                    .importer
-                    .miner
-                    .import_external_transactions(client, txs);
-            })
-            .unwrap_or_else(|e| {
-                debug!(target: "client", "Ignoring {} transactions: {}", len, e);
-            });
-    }
-
-    fn queue_ancient_block(
-        &self,
-        unverified: Unverified,
-        receipts_bytes: Bytes,
-    ) -> EthcoreResult<H256> {
-        trace_time!("queue_ancient_block");
-
-        let hash = unverified.hash();
-        {
-            // check block order
-            if self.chain.read().is_known(&hash) {
-                bail!(EthcoreErrorKind::Import(ImportErrorKind::AlreadyInChain));
-            }
-            let parent_hash = unverified.parent_hash();
-            // NOTE To prevent race condition with import, make sure to check queued blocks first
-            // (and attempt to acquire lock)
-            let is_parent_pending = self.queued_ancient_blocks.read().contains(&parent_hash);
-            if !is_parent_pending && !self.chain.read().is_known(&parent_hash) {
-                bail!(EthcoreErrorKind::Block(BlockError::UnknownParent(
-                    parent_hash
-                )));
-            }
-        }
-
-        // we queue blocks here and trigger an Executer.
-        {
-            let mut queued = self.queued_ancient_blocks.write();
-            queued.insert(hash);
-        }
-
-        // see content of executer in Client::new()
-        match self.queued_ancient_blocks_executer.lock().as_ref() {
-            Some(queue) => {
-                if !queue.enqueue((unverified, receipts_bytes)) {
-                    bail!(EthcoreErrorKind::Queue(QueueErrorKind::Full(
-                        ANCIENT_BLOCKS_QUEUE_SIZE
-                    )));
-                }
-            }
-            None => (),
-        }
-        Ok(hash)
-    }
-
-    fn ancient_block_queue_fullness(&self) -> f32 {
-        match self.queued_ancient_blocks_executer.lock().as_ref() {
-            Some(queue) => queue.len() as f32 / ANCIENT_BLOCKS_QUEUE_SIZE as f32,
-            None => 1.0, //return 1.0 if queue is not set
-        }
-    }
-
-    fn queue_consensus_message(&self, message: Bytes) {
-        match self
-            .queue_consensus_message
-            .queue(&self.io_channel.read(), 1, move |client| {
-                if let Err(e) = client.engine().handle_message(&message) {
-                    debug!(target: "poa", "Invalid message received: {}", e);
-                }
-            }) {
-            Ok(_) => (),
-            Err(e) => {
-                debug!(target: "poa", "Ignoring the message, error queueing: {}", e);
-            }
-        }
     }
 }
 
@@ -2900,12 +1401,6 @@ impl PrepareOpenBlock for Client {
 }
 
 impl BlockProducer for Client {}
-
-impl ScheduleInfo for Client {
-    fn latest_schedule(&self) -> Schedule {
-        self.engine.schedule(self.latest_env_info().number)
-    }
-}
 
 impl ImportSealedBlock for Client {
     fn import_sealed_block(&self, block: SealedBlock) -> EthcoreResult<H256> {
@@ -3036,54 +1531,6 @@ impl super::traits::EngineClient for Client {
 
     fn block_header(&self, id: BlockId) -> Option<encoded::Header> {
         BlockChainClient::block_header(self, id)
-    }
-}
-
-impl ProvingBlockChainClient for Client {
-    fn prove_storage(&self, key1: H256, key2: H256, id: BlockId) -> Option<(Vec<Bytes>, H256)> {
-        self.state_at(id)
-            .and_then(move |state| state.prove_storage(key1, key2).ok())
-    }
-
-    fn prove_account(
-        &self,
-        key1: H256,
-        id: BlockId,
-    ) -> Option<(Vec<Bytes>, ::types::basic_account::BasicAccount)> {
-        self.state_at(id)
-            .and_then(move |state| state.prove_account(key1).ok())
-    }
-
-    fn prove_transaction(
-        &self,
-        transaction: SignedTransaction,
-        id: BlockId,
-    ) -> Option<(Bytes, Vec<DBValue>)> {
-        let (header, mut env_info) = match (self.block_header(id), self.env_info(id)) {
-            (Some(s), Some(e)) => (s, e),
-            _ => return None,
-        };
-
-        env_info.gas_limit = transaction.tx().gas.clone();
-        let mut jdb = self.state_db.read().journal_db().boxed_clone();
-
-        state::prove_transaction_virtual(
-            jdb.as_hash_db_mut(),
-            header.state_root().clone(),
-            &transaction,
-            self.engine.machine(),
-            &env_info,
-            self.factories.clone(),
-        )
-    }
-
-    fn epoch_signal(&self, hash: H256) -> Option<Vec<u8>> {
-        // pending transitions are never deleted, and do not contain
-        // finality proofs by definition.
-        self.chain
-            .read()
-            .get_pending_transition(hash)
-            .map(|pending| pending.proof)
     }
 }
 
@@ -3219,7 +1666,7 @@ impl ImportExportBlocks for Client {
 
 /// Returns `LocalizedReceipt` given `LocalizedTransaction`
 /// and a vector of receipts from given block up to transaction index.
-fn transaction_receipt(
+pub fn transaction_receipt(
     machine: &::machine::EthereumMachine,
     mut tx: LocalizedTransaction,
     receipt: TypedReceipt,
@@ -3279,8 +1726,9 @@ fn transaction_receipt(
     }
 }
 
+
 /// Queue some items to be processed by IO client.
-struct IoChannelQueue {
+pub struct IoChannelQueue {
     /// Using a *signed* integer for counting currently queued messages since the
     /// order in which the counter is incremented and decremented is not defined.
     /// Using an unsigned integer can (and will) result in integer underflow,
@@ -3307,7 +1755,7 @@ impl IoChannelQueue {
     where
         F: Fn(&Client) + Send + Sync + 'static,
     {
-        let queue_size = self.currently_queued.load(AtomicOrdering::SeqCst);
+        let queue_size = self.currently_queued.load(Ordering::SeqCst);
         if queue_size >= self.limit {
             let err_limit = usize::try_from(self.limit).unwrap_or(usize::max_value());
             bail!("The queue is full ({})", err_limit);
@@ -3317,155 +1765,15 @@ impl IoChannelQueue {
 
         let currently_queued = self.currently_queued.clone();
         let _ok = channel.send(ClientIoMessage::execute(move |client| {
-            currently_queued.fetch_sub(count, AtomicOrdering::SeqCst);
+            currently_queued.fetch_sub(count, Ordering::SeqCst);
             fun(client);
         }))?;
 
-        self.currently_queued
-            .fetch_add(count, AtomicOrdering::SeqCst);
+        self.currently_queued.fetch_add(count, Ordering::SeqCst);
         Ok(())
     }
 }
 
-impl PrometheusMetrics for Client {
-    fn prometheus_metrics(&self, r: &mut PrometheusRegistry) {
-        // gas, tx & blocks
-        let report = self.report();
-
-        for (key, value) in report.item_sizes.iter() {
-            r.register_gauge(
-                &key,
-                format!("Total item number of {}", key).as_str(),
-                *value as i64,
-            );
-        }
-
-        r.register_counter(
-            "import_gas",
-            "Gas processed",
-            report.gas_processed.as_u64() as i64,
-        );
-        r.register_counter(
-            "import_blocks",
-            "Blocks imported",
-            report.blocks_imported as i64,
-        );
-        r.register_counter(
-            "import_txs",
-            "Transactions applied",
-            report.transactions_applied as i64,
-        );
-
-        let state_db = self.state_db.read();
-        r.register_gauge(
-            "statedb_cache_size",
-            "State DB cache size",
-            state_db.cache_size() as i64,
-        );
-
-        // blockchain cache
-        let blockchain_cache_info = self.blockchain_cache_info();
-        r.register_gauge(
-            "blockchaincache_block_details",
-            "BlockDetails cache size",
-            blockchain_cache_info.block_details as i64,
-        );
-        r.register_gauge(
-            "blockchaincache_block_recipts",
-            "Block receipts size",
-            blockchain_cache_info.block_receipts as i64,
-        );
-        r.register_gauge(
-            "blockchaincache_blocks",
-            "Blocks cache size",
-            blockchain_cache_info.blocks as i64,
-        );
-        r.register_gauge(
-            "blockchaincache_txaddrs",
-            "Transaction addresses cache size",
-            blockchain_cache_info.transaction_addresses as i64,
-        );
-        r.register_gauge(
-            "blockchaincache_size",
-            "Total blockchain cache size",
-            blockchain_cache_info.total() as i64,
-        );
-
-        // chain info
-        let chain = self.chain_info();
-
-        let gap = chain
-            .ancient_block_number
-            .map(|x| U256::from(x + 1))
-            .and_then(|first| {
-                chain
-                    .first_block_number
-                    .map(|last| (first, U256::from(last)))
-            });
-        if let Some((first, last)) = gap {
-            r.register_gauge(
-                "chain_warpsync_gap_first",
-                "Warp sync gap, first block",
-                first.as_u64() as i64,
-            );
-            r.register_gauge(
-                "chain_warpsync_gap_last",
-                "Warp sync gap, last block",
-                last.as_u64() as i64,
-            );
-        }
-
-        r.register_gauge(
-            "chain_block",
-            "Best block number",
-            chain.best_block_number as i64,
-        );
-
-        // prunning info
-        let prunning = self.pruning_info();
-        r.register_gauge(
-            "prunning_earliest_chain",
-            "The first block which everything can be served after",
-            prunning.earliest_chain as i64,
-        );
-        r.register_gauge(
-            "prunning_earliest_state",
-            "The first block where state requests may be served",
-            prunning.earliest_state as i64,
-        );
-
-        // queue info
-        let queue = self.queue_info();
-        r.register_gauge(
-            "queue_mem_used",
-            "Queue heap memory used in bytes",
-            queue.mem_used as i64,
-        );
-        r.register_gauge(
-            "queue_size_total",
-            "The total size of the queues",
-            queue.total_queue_size() as i64,
-        );
-        r.register_gauge(
-            "queue_size_unverified",
-            "Number of queued items pending verification",
-            queue.unverified_queue_size as i64,
-        );
-        r.register_gauge(
-            "queue_size_verified",
-            "Number of verified queued items pending import",
-            queue.verified_queue_size as i64,
-        );
-        r.register_gauge(
-            "queue_size_verifying",
-            "Number of items being verified",
-            queue.verifying_queue_size as i64,
-        );
-
-        // database info
-        self.db.read().key_value().prometheus_metrics(r);
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -3476,7 +1784,7 @@ mod tests {
 
     #[test]
     fn should_not_cache_details_before_commit() {
-        use client::{BlockChainClient, ChainInfo};
+        use client::{blockchain::BlockChainClient, ChainInfo};
         use test_helpers::{generate_dummy_client, get_good_dummy_block_hash};
 
         use kvdb::DBTransaction;
@@ -3524,7 +1832,7 @@ mod tests {
 
     #[test]
     fn should_return_block_receipts() {
-        use client::{BlockChainClient, BlockId, TransactionId};
+        use client::{blockchain::BlockChainClient, BlockId, TransactionId};
         use test_helpers::generate_dummy_client_with_data;
 
         let client = generate_dummy_client_with_data(2, 2, &[1.into(), 1.into()]);

--- a/crates/ethcore/src/client/config.rs
+++ b/crates/ethcore/src/client/config.rs
@@ -14,10 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-    fmt::{Display, Error as FmtError, Formatter},
-    str::FromStr,
-};
+use std::str::FromStr;
 
 use journaldb;
 use snapshot::SnapshotConfiguration;
@@ -27,6 +24,8 @@ pub use blockchain::Config as BlockChainConfig;
 pub use evm::VMType;
 pub use std::time::Duration;
 pub use trace::Config as TraceConfig;
+
+use super::Mode;
 
 /// Client state db compaction profile
 #[derive(Debug, PartialEq, Clone)]
@@ -54,32 +53,6 @@ impl FromStr for DatabaseCompactionProfile {
             "ssd" => Ok(DatabaseCompactionProfile::SSD),
             "hdd" => Ok(DatabaseCompactionProfile::HDD),
             _ => Err("Invalid compaction profile given. Expected default/hdd/ssd.".into()),
-        }
-    }
-}
-
-/// Operating mode for the client.
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Mode {
-    /// Always on.
-    Active,
-    /// Goes offline after client is inactive for some (given) time, but
-    /// comes back online after a while of inactivity.
-    Passive(Duration, Duration),
-    /// Goes offline after client is inactive for some (given) time and
-    /// stays inactive.
-    Dark(Duration),
-    /// Always off.
-    Off,
-}
-
-impl Display for Mode {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-        match *self {
-            Mode::Active => write!(f, "active"),
-            Mode::Passive(..) => write!(f, "passive"),
-            Mode::Dark(..) => write!(f, "dark"),
-            Mode::Off => write!(f, "offline"),
         }
     }
 }

--- a/crates/ethcore/src/client/importer.rs
+++ b/crates/ethcore/src/client/importer.rs
@@ -28,18 +28,15 @@ use crate::{
     verification::{self, queue::kind::blocks::Unverified, BlockQueue, PreverifiedBlock, Verifier},
 };
 use block::enact_verified;
-use blockchain::BlockProvider;
-use blockchain::{BlockChain, ExtrasInsert, ImportRoute};
-use db::DBTransaction;
-use db::KeyValueDB;
+use blockchain::{BlockChain, BlockProvider, ExtrasInsert, ImportRoute};
+use db::{DBTransaction, KeyValueDB};
 use engines::{epoch::Transition, EngineError, EthEngine};
 use error::EthcoreResult;
 use ethereum_types::{H256, U256};
 use evm::EnvInfo;
 use executive::{Executive, TransactOptions};
 use io::IoChannel;
-use miner::Miner;
-use miner::MinerService;
+use miner::{Miner, MinerService};
 use parking_lot::Mutex;
 use rand::rngs::OsRng;
 use rlp::Rlp;
@@ -49,8 +46,7 @@ use trace::{Database, ImportRequest};
 use types::{
     ancestry_action::AncestryAction,
     encoded,
-    engines::epoch::PendingTransition,
-    engines::ForkChoice,
+    engines::{epoch::PendingTransition, ForkChoice},
     header::{ExtendedHeader, Header},
     ids::BlockId,
     receipt::TypedReceipt,

--- a/crates/ethcore/src/client/importer.rs
+++ b/crates/ethcore/src/client/importer.rs
@@ -1,0 +1,695 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::{
+    ancient_import::AncientVerifier,
+    bad_blocks,
+    blockchain::BlockChainClient,
+    chain_notify::{ChainRoute, NewBlocks},
+    Client, ClientConfig, ClientIoMessage,
+};
+use crate::{
+    block::{Drain, LockedBlock},
+    error,
+    state_db::StateDB,
+    verification::{self, queue::kind::blocks::Unverified, BlockQueue, PreverifiedBlock, Verifier},
+};
+use block::enact_verified;
+use blockchain::BlockProvider;
+use blockchain::{BlockChain, ExtrasInsert, ImportRoute};
+use db::DBTransaction;
+use db::KeyValueDB;
+use engines::{epoch::Transition, EngineError, EthEngine};
+use error::EthcoreResult;
+use ethereum_types::{H256, U256};
+use evm::EnvInfo;
+use executive::{Executive, TransactOptions};
+use io::IoChannel;
+use miner::Miner;
+use miner::MinerService;
+use parking_lot::Mutex;
+use rand::rngs::OsRng;
+use rlp::Rlp;
+use state::State;
+use std::{collections::HashSet, sync::Arc, time::Instant};
+use trace::{Database, ImportRequest};
+use types::{
+    ancestry_action::AncestryAction,
+    encoded,
+    engines::epoch::PendingTransition,
+    engines::ForkChoice,
+    header::{ExtendedHeader, Header},
+    ids::BlockId,
+    receipt::TypedReceipt,
+};
+
+pub struct Importer {
+    /// Lock used during block import
+    pub import_lock: Mutex<()>, // FIXME Maybe wrap the whole `Importer` instead?
+
+    /// Used to verify blocks
+    pub verifier: Box<dyn Verifier<Client>>,
+
+    /// Queue containing pending blocks
+    pub block_queue: BlockQueue,
+
+    /// Handles block sealing
+    pub miner: Arc<Miner>,
+
+    /// Ancient block verifier: import an ancient sequence of blocks in order from a starting epoch
+    pub ancient_verifier: AncientVerifier,
+
+    /// Ethereum engine to be used during import
+    pub engine: Arc<dyn EthEngine>,
+
+    /// A lru cache of recently detected bad blocks
+    pub bad_blocks: bad_blocks::BadBlocks,
+}
+
+impl Importer {
+    pub fn new(
+        config: &ClientConfig,
+        engine: Arc<dyn EthEngine>,
+        message_channel: IoChannel<ClientIoMessage>,
+        miner: Arc<Miner>,
+    ) -> Result<Importer, error::Error> {
+        let block_queue = BlockQueue::new(
+            config.queue.clone(),
+            engine.clone(),
+            message_channel.clone(),
+            config.verifier_type.verifying_seal(),
+        );
+
+        Ok(Importer {
+            import_lock: Mutex::new(()),
+            verifier: verification::new(config.verifier_type.clone()),
+            block_queue,
+            miner,
+            ancient_verifier: AncientVerifier::new(engine.clone()),
+            engine,
+            bad_blocks: Default::default(),
+        })
+    }
+
+    // t_nb 6.0 This is triggered by a message coming from a block queue when the block is ready for insertion
+    pub fn import_verified_blocks(&self, client: &Client) -> usize {
+        // Shortcut out if we know we're incapable of syncing the chain.
+        trace!(target: "block_import", "fn import_verified_blocks");
+        if !client.enabled() {
+            self.block_queue.reset_verification_ready_signal();
+            return 0;
+        }
+
+        let max_blocks_to_import = client.config.max_round_blocks_to_import;
+        let (
+            imported_blocks,
+            import_results,
+            invalid_blocks,
+            imported,
+            proposed_blocks,
+            duration,
+            has_more_blocks_to_import,
+        ) = {
+            let mut imported_blocks = Vec::with_capacity(max_blocks_to_import);
+            let mut invalid_blocks = HashSet::new();
+            let proposed_blocks = Vec::with_capacity(max_blocks_to_import);
+            let mut import_results = Vec::with_capacity(max_blocks_to_import);
+
+            let _import_lock = self.import_lock.lock();
+            let blocks = self.block_queue.drain(max_blocks_to_import);
+            if blocks.is_empty() {
+                debug!(target: "block_import", "block_queue is empty");
+                self.block_queue.resignal_verification();
+                return 0;
+            }
+            trace_time!("import_verified_blocks");
+            let start = Instant::now();
+
+            for block in blocks {
+                let header = block.header.clone();
+                let bytes = block.bytes.clone();
+                let hash = header.hash();
+
+                let is_invalid = invalid_blocks.contains(header.parent_hash());
+                if is_invalid {
+                    debug!(
+                        target: "block_import",
+                        "Refusing block #{}({}) with invalid parent {}",
+                        header.number(),
+                        header.hash(),
+                        header.parent_hash()
+                    );
+                    invalid_blocks.insert(hash);
+                    continue;
+                }
+                // t_nb 7.0 check and lock block
+                match self.check_and_lock_block(&bytes, block, client) {
+                    Ok((closed_block, pending)) => {
+                        imported_blocks.push(hash);
+                        let transactions_len = closed_block.transactions.len();
+                        trace!(target:"block_import","Block #{}({}) check pass",header.number(),header.hash());
+                        // t_nb 8.0 commit block to db
+                        let route = self.commit_block(
+                            closed_block,
+                            &header,
+                            encoded::Block::new(bytes),
+                            pending,
+                            client,
+                        );
+                        trace!(target:"block_import","Block #{}({}) commited",header.number(),header.hash());
+                        import_results.push(route);
+                        client
+                            .report
+                            .write()
+                            .accrue_block(&header, transactions_len);
+                    }
+                    Err(err) => {
+                        self.bad_blocks.report(bytes, format!("{:?}", err));
+                        invalid_blocks.insert(hash);
+                    }
+                }
+            }
+
+            let imported = imported_blocks.len();
+            let invalid_blocks = invalid_blocks.into_iter().collect::<Vec<H256>>();
+
+            if !invalid_blocks.is_empty() {
+                self.block_queue.mark_as_bad(&invalid_blocks);
+            }
+            let has_more_blocks_to_import = !self.block_queue.mark_as_good(&imported_blocks);
+            (
+                imported_blocks,
+                import_results,
+                invalid_blocks,
+                imported,
+                proposed_blocks,
+                start.elapsed(),
+                has_more_blocks_to_import,
+            )
+        };
+
+        {
+            if !imported_blocks.is_empty() {
+                trace!(target:"block_import","Imported block, notify rest of system");
+                let route = ChainRoute::from(import_results.as_ref());
+
+                // t_nb 10 Notify miner about new included block.
+                if !has_more_blocks_to_import {
+                    self.miner.chain_new_blocks(
+                        client,
+                        &imported_blocks,
+                        &invalid_blocks,
+                        route.enacted(),
+                        route.retracted(),
+                        false,
+                    );
+                }
+
+                // t_nb 11 notify rest of system about new block inclusion
+                client.notify(|notify| {
+                    notify.new_blocks(NewBlocks::new(
+                        imported_blocks.clone(),
+                        invalid_blocks.clone(),
+                        route.clone(),
+                        Vec::new(),
+                        proposed_blocks.clone(),
+                        duration,
+                        has_more_blocks_to_import,
+                    ));
+                });
+            }
+        }
+        trace!(target:"block_import","Flush block to db");
+        let db = client.db.read();
+        db.key_value().flush().expect("DB flush failed.");
+
+        self.block_queue.resignal_verification();
+        trace!(target:"block_import","Resignal verifier");
+        imported
+    }
+
+    // t_nb 6.0.1 check and lock block,
+    fn check_and_lock_block(
+        &self,
+        bytes: &[u8],
+        block: PreverifiedBlock,
+        client: &Client,
+    ) -> EthcoreResult<(LockedBlock, Option<PendingTransition>)> {
+        let engine = &*self.engine;
+        let header = block.header.clone();
+
+        // Check the block isn't so old we won't be able to enact it.
+        // t_nb 7.1 check if block is older then last pruned block
+        let best_block_number = client.chain.read().best_block_number();
+        if client.pruning_info().earliest_state > header.number() {
+            warn!(target: "client", "Block import failed for #{} ({})\nBlock is ancient (current best block: #{}).", header.number(), header.hash(), best_block_number);
+            bail!("Block is ancient");
+        }
+
+        // t_nb 7.2 Check if parent is in chain
+        let parent = match client.block_header_decoded(BlockId::Hash(*header.parent_hash())) {
+            Some(h) => h,
+            None => {
+                warn!(target: "client", "Block import failed for #{} ({}): Parent not found ({}) ", header.number(), header.hash(), header.parent_hash());
+                bail!("Parent not found");
+            }
+        };
+
+        let chain = client.chain.read();
+        // t_nb 7.3 verify block family
+        let verify_family_result = self.verifier.verify_block_family(
+            &header,
+            &parent,
+            engine,
+            Some(verification::FullFamilyParams {
+                block: &block,
+                block_provider: &**chain,
+                client,
+            }),
+        );
+
+        if let Err(e) = verify_family_result {
+            warn!(target: "client", "Stage 3 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+            bail!(e);
+        };
+
+        // t_nb 7.4 verify block external
+        let verify_external_result = self.verifier.verify_block_external(&header, engine);
+        if let Err(e) = verify_external_result {
+            warn!(target: "client", "Stage 4 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+            bail!(e);
+        };
+
+        // Enact Verified Block
+        // t_nb 7.5 Get build last hashes. Get parent state db. Get epoch_transition
+        let last_hashes = client.build_last_hashes(header.parent_hash());
+
+        let db = client
+            .state_db
+            .read()
+            .boxed_clone_canon(header.parent_hash());
+
+        let is_epoch_begin = chain
+            .epoch_transition(parent.number(), *header.parent_hash())
+            .is_some();
+
+        // t_nb 8.0 Block enacting. Execution of transactions.
+        let enact_result = enact_verified(
+            block,
+            engine,
+            client.tracedb.read().tracing_enabled(),
+            db,
+            &parent,
+            last_hashes,
+            client.factories.clone(),
+            is_epoch_begin,
+            &mut chain.ancestry_with_metadata_iter(*header.parent_hash()),
+        );
+
+        let mut locked_block = match enact_result {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(target: "client", "Block import failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+                bail!(e);
+            }
+        };
+
+        // t_nb 7.6 Strip receipts for blocks before validate_receipts_transition,
+        // if the expected receipts root header does not match.
+        // (i.e. allow inconsistency in receipts outcome before the transition block)
+        if header.number() < engine.params().validate_receipts_transition
+            && header.receipts_root() != locked_block.header.receipts_root()
+        {
+            locked_block.strip_receipts_outcomes();
+        }
+
+        // t_nb 7.7 Final Verification. See if block that we created (executed) matches exactly with block that we received.
+        if let Err(e) = self
+            .verifier
+            .verify_block_final(&header, &locked_block.header)
+        {
+            warn!(target: "client", "Stage 5 block verification failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
+            bail!(e);
+        }
+
+        let pending = self.check_epoch_end_signal(
+            &header,
+            bytes,
+            &locked_block.receipts,
+            locked_block.state.db(),
+            client,
+        )?;
+
+        Ok((locked_block, pending))
+    }
+
+    /// Import a block with transaction receipts.
+    ///
+    /// The block is guaranteed to be the next best blocks in the
+    /// first block sequence. Does no sealing or transaction validation.
+    pub fn import_old_block(
+        &self,
+        unverified: Unverified,
+        receipts_bytes: &[u8],
+        db: &dyn KeyValueDB,
+        chain: &BlockChain,
+    ) -> EthcoreResult<()> {
+        let receipts = TypedReceipt::decode_rlp_list(&Rlp::new(receipts_bytes))
+            .unwrap_or_else(|e| panic!("Receipt bytes should be valid: {:?}", e));
+        let _import_lock = self.import_lock.lock();
+
+        if unverified.header.number() >= chain.best_block_header().number() {
+            panic!("Ancient block number is higher then best block number");
+        }
+
+        {
+            trace_time!("import_old_block");
+            // verify the block, passing the chain for updating the epoch verifier.
+            let mut rng = OsRng;
+            self.ancient_verifier
+                .verify(&mut rng, &unverified.header, &chain)?;
+
+            // Commit results
+            let mut batch = DBTransaction::new();
+            chain.insert_unordered_block(
+                &mut batch,
+                encoded::Block::new(unverified.bytes),
+                receipts,
+                None,
+                false,
+                true,
+            );
+            // Final commit to the DB
+            db.write_buffered(batch);
+            chain.commit();
+        }
+        db.flush().expect("DB flush failed.");
+        Ok(())
+    }
+
+    // NOTE: the header of the block passed here is not necessarily sealed, as
+    // it is for reconstructing the state transition.
+    //
+    // The header passed is from the original block data and is sealed.
+    // TODO: should return an error if ImportRoute is none, issue #9910
+    pub fn commit_block<B>(
+        &self,
+        block: B,
+        header: &Header,
+        block_data: encoded::Block,
+        pending: Option<PendingTransition>,
+        client: &Client,
+    ) -> ImportRoute
+    where
+        B: Drain,
+    {
+        let hash = &header.hash();
+        let number = header.number();
+        let parent = header.parent_hash();
+        let chain = client.chain.read();
+        let mut is_finalized = false;
+
+        // Commit results
+        let block = block.drain();
+        debug_assert_eq!(header.hash(), block_data.header_view().hash());
+
+        let mut batch = DBTransaction::new();
+
+        // t_nb 9.1 Gather all ancestry actions. (Used only by AuRa)
+        let ancestry_actions = self
+            .engine
+            .ancestry_actions(&header, &mut chain.ancestry_with_metadata_iter(*parent));
+
+        let receipts = block.receipts;
+        let traces = block.traces.drain();
+        let best_hash = chain.best_block_hash();
+
+        let new = ExtendedHeader {
+            header: header.clone(),
+            is_finalized,
+            parent_total_difficulty: chain
+                .block_details(&parent)
+                .expect("Parent block is in the database; qed")
+                .total_difficulty,
+        };
+
+        let best = {
+            let hash = best_hash;
+            let header = chain
+                .block_header_data(&hash)
+                .expect("Best block is in the database; qed")
+                .decode()
+                .expect("Stored block header is valid RLP; qed");
+            let details = chain
+                .block_details(&hash)
+                .expect("Best block is in the database; qed");
+
+            ExtendedHeader {
+                parent_total_difficulty: details.total_difficulty - *header.difficulty(),
+                is_finalized: details.is_finalized,
+                header: header,
+            }
+        };
+
+        // t_nb 9.2 calcuate route between current and latest block.
+        let route = chain.tree_route(best_hash, *parent).expect("forks are only kept when it has common ancestors; tree route from best to prospective's parent always exists; qed");
+
+        // t_nb 9.3 Check block total difficulty
+        let fork_choice = if route.is_from_route_finalized {
+            ForkChoice::Old
+        } else {
+            self.engine.fork_choice(&new, &best)
+        };
+
+        // t_nb 9.4 CHECK! I *think* this is fine, even if the state_root is equal to another
+        // already-imported block of the same number.
+        // TODO: Prove it with a test.
+        let mut state = block.state.drop().1;
+
+        // t_nb 9.5 check epoch end signal, potentially generating a proof on the current
+        // state. Write transition into db.
+        if let Some(pending) = pending {
+            chain.insert_pending_transition(&mut batch, header.hash(), pending);
+        }
+
+        // t_nb 9.6 push state to database Transaction. (It calls journal_under from JournalDB)
+        state
+            .journal_under(&mut batch, number, hash)
+            .expect("DB commit failed");
+
+        let finalized: Vec<_> = ancestry_actions
+            .into_iter()
+            .map(|ancestry_action| {
+                let AncestryAction::MarkFinalized(a) = ancestry_action;
+
+                if a != header.hash() {
+                    // t_nb 9.7 if there are finalized ancester, mark that chainge in block in db. (Used by AuRa)
+                    chain
+                        .mark_finalized(&mut batch, a)
+                        .expect("Engine's ancestry action must be known blocks; qed");
+                } else {
+                    // we're finalizing the current block
+                    is_finalized = true;
+                }
+
+                a
+            })
+            .collect();
+
+        // t_nb 9.8 insert block
+        let route = chain.insert_block(
+            &mut batch,
+            block_data,
+            receipts.clone(),
+            ExtrasInsert {
+                fork_choice: fork_choice,
+                is_finalized,
+            },
+        );
+
+        // t_nb 9.9 insert traces (if they are enabled)
+        client.tracedb.read().import(
+            &mut batch,
+            ImportRequest {
+                traces: traces.into(),
+                block_hash: hash.clone(),
+                block_number: number,
+                enacted: route.enacted.clone(),
+                retracted: route.retracted.len(),
+            },
+        );
+
+        let is_canon = route.enacted.last().map_or(false, |h| h == hash);
+
+        // t_nb 9.10 sync cache
+        state.sync_cache(&route.enacted, &route.retracted, is_canon);
+        // Final commit to the DB
+        // t_nb 9.11 Write Transaction to database (cached)
+        client.db.read().key_value().write_buffered(batch);
+        // t_nb 9.12 commit changed to become current greatest by applying pending insertion updates (Sync point)
+        chain.commit();
+
+        // t_nb 9.13 check epoch end. Related only to AuRa and it seems light engine
+        self.check_epoch_end(&header, &finalized, &chain, client);
+
+        // t_nb 9.14 update last hashes. They are build in step 7.5
+        client.update_last_hashes(&parent, hash);
+
+        // t_nb 9.15 prune ancient states
+        if let Err(e) = client.prune_ancient(state, &chain) {
+            warn!("Failed to prune ancient state data: {}", e);
+        }
+
+        route
+    }
+
+    // check for epoch end signal and write pending transition if it occurs.
+    // state for the given block must be available.
+    pub fn check_epoch_end_signal(
+        &self,
+        header: &Header,
+        block_bytes: &[u8],
+        receipts: &[TypedReceipt],
+        state_db: &StateDB,
+        client: &Client,
+    ) -> EthcoreResult<Option<PendingTransition>> {
+        use engines::EpochChange;
+
+        let hash = header.hash();
+        let auxiliary = ::machine::AuxiliaryData {
+            bytes: Some(block_bytes),
+            receipts: Some(&receipts),
+        };
+
+        match self.engine.signals_epoch_end(header, auxiliary) {
+            EpochChange::Yes(proof) => {
+                use engines::Proof;
+
+                let proof = match proof {
+                    Proof::Known(proof) => proof,
+                    Proof::WithState(with_state) => {
+                        let env_info = EnvInfo {
+                            number: header.number(),
+                            author: header.author().clone(),
+                            timestamp: header.timestamp(),
+                            difficulty: header.difficulty().clone(),
+                            last_hashes: client.build_last_hashes(header.parent_hash()),
+                            gas_used: U256::default(),
+                            gas_limit: u64::max_value().into(),
+                        };
+
+                        let call = move |addr, data| {
+                            let mut state_db = state_db.boxed_clone();
+                            let backend = ::state::backend::Proving::new(state_db.as_hash_db_mut());
+
+                            let transaction = client.contract_call_tx(
+                                BlockId::Hash(*header.parent_hash()),
+                                addr,
+                                data,
+                            );
+
+                            let mut state = State::from_existing(
+                                backend,
+                                header.state_root().clone(),
+                                self.engine.account_start_nonce(header.number()),
+                                client.factories.clone(),
+                            )
+                            .expect("state known to be available for just-imported block; qed");
+
+                            let options = TransactOptions::with_no_tracing().dont_check_nonce();
+                            let machine = self.engine.machine();
+                            let schedule = machine.schedule(env_info.number);
+                            let res = Executive::new(&mut state, &env_info, &machine, &schedule)
+                                .transact(&transaction, options);
+
+                            let res = match res {
+                                Err(e) => {
+                                    trace!(target: "client", "Proved call failed: {}", e);
+                                    Err(e.to_string())
+                                }
+                                Ok(res) => Ok((res.output, state.drop().1.extract_proof())),
+                            };
+
+                            res.map(|(output, proof)| {
+                                (output, proof.into_iter().map(|x| x.into_vec()).collect())
+                            })
+                        };
+
+                        match with_state.generate_proof(&call) {
+                            Ok(proof) => proof,
+                            Err(e) => {
+                                warn!(target: "client", "Failed to generate transition proof for block {}: {}", hash, e);
+                                warn!(target: "client", "Snapshots produced by this client may be incomplete");
+                                return Err(EngineError::FailedSystemCall(e).into());
+                            }
+                        }
+                    }
+                };
+
+                debug!(target: "client", "Block {} signals epoch end.", hash);
+
+                Ok(Some(PendingTransition { proof: proof }))
+            }
+            EpochChange::No => Ok(None),
+            EpochChange::Unsure(_) => {
+                warn!(target: "client", "Detected invalid engine implementation.");
+                warn!(target: "client", "Engine claims to require more block data, but everything provided.");
+                Err(EngineError::InvalidEngine.into())
+            }
+        }
+    }
+
+    // check for ending of epoch and write transition if it occurs.
+    fn check_epoch_end<'a>(
+        &self,
+        header: &'a Header,
+        finalized: &'a [H256],
+        chain: &BlockChain,
+        client: &Client,
+    ) {
+        let is_epoch_end = self.engine.is_epoch_end(
+            header,
+            finalized,
+            &(|hash| client.block_header_decoded(BlockId::Hash(hash))),
+            &(|hash| chain.get_pending_transition(hash)), // TODO: limit to current epoch.
+        );
+
+        if let Some(proof) = is_epoch_end {
+            debug!(target: "client", "Epoch transition at block {}", header.hash());
+
+            let mut batch = DBTransaction::new();
+            chain.insert_epoch_transition(
+                &mut batch,
+                header.number(),
+                Transition {
+                    block_hash: header.hash(),
+                    block_number: header.number(),
+                    proof: proof,
+                },
+            );
+
+            // always write the batch directly since epoch transition proofs are
+            // fetched from a DB iterator and DB iterators are only available on
+            // flushed data.
+            client
+                .db
+                .read()
+                .key_value()
+                .write(batch)
+                .expect("DB flush failed");
+        }
+    }
+}

--- a/crates/ethcore/src/client/info.rs
+++ b/crates/ethcore/src/client/info.rs
@@ -1,0 +1,123 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use super::Client;
+use crate::engines::EthEngine;
+
+use blockchain::BlockProvider;
+use ethereum_types::{Address, H256};
+use evm::Schedule;
+use types::{
+    blockchain_info::BlockChainInfo,
+    encoded,
+    header::Header,
+    ids::{BlockId, TransactionId},
+};
+
+/// Provides various blockchain information, like block header, chain state etc.
+pub trait BlockChain: ChainInfo + BlockInfo + TransactionInfo {}
+impl BlockChain for Client {}
+
+/// Provides `chain_info` method
+pub trait ChainInfo {
+    /// Get blockchain information.
+    fn chain_info(&self) -> BlockChainInfo;
+}
+
+impl ChainInfo for Client {
+    fn chain_info(&self) -> BlockChainInfo {
+        let mut chain_info = self.chain.read().chain_info();
+        chain_info.pending_total_difficulty =
+            chain_info.total_difficulty + self.importer.block_queue.total_difficulty();
+        chain_info
+    }
+}
+
+/// Provides various information on a block by it's ID
+pub trait BlockInfo {
+    /// Get raw block header data by block id.
+    fn block_header(&self, id: BlockId) -> Option<encoded::Header>;
+
+    /// Get the best block header.
+    fn best_block_header(&self) -> Header;
+
+    /// Get raw block data by block header hash.
+    fn block(&self, id: BlockId) -> Option<encoded::Block>;
+
+    /// Get address code hash at given block's state.
+    fn code_hash(&self, address: &Address, id: BlockId) -> Option<H256>;
+}
+
+impl BlockInfo for Client {
+    fn block_header(&self, id: BlockId) -> Option<encoded::Header> {
+        let chain = self.chain.read();
+
+        Self::block_hash(&chain, id).and_then(|hash| chain.block_header_data(&hash))
+    }
+
+    fn best_block_header(&self) -> Header {
+        self.chain.read().best_block_header()
+    }
+
+    fn block(&self, id: BlockId) -> Option<encoded::Block> {
+        let chain = self.chain.read();
+
+        Self::block_hash(&chain, id).and_then(|hash| chain.block(&hash))
+    }
+
+    fn code_hash(&self, address: &Address, id: BlockId) -> Option<H256> {
+        self.state_at(id)
+            .and_then(|s| s.code_hash(address).unwrap_or(None))
+    }
+}
+
+/// Provides various information on a transaction by it's ID
+pub trait TransactionInfo {
+    /// Get the hash of block that contains the transaction, if any.
+    fn transaction_block(&self, id: TransactionId) -> Option<H256>;
+}
+
+impl TransactionInfo for Client {
+    fn transaction_block(&self, id: TransactionId) -> Option<H256> {
+        self.transaction_address(id).map(|addr| addr.block_hash)
+    }
+}
+
+/// Provides `engine` method
+pub trait EngineInfo {
+    /// Get underlying engine object
+    fn engine(&self) -> Arc<dyn EthEngine>;
+}
+
+impl EngineInfo for Client {
+    fn engine(&self) -> Arc<dyn EthEngine> {
+        self.engine()
+    }
+}
+
+/// Provides `latest_schedule` method
+pub trait ScheduleInfo {
+    /// Returns latest schedule.
+    fn latest_schedule(&self) -> Schedule;
+}
+
+impl ScheduleInfo for Client {
+    fn latest_schedule(&self) -> Schedule {
+        self.engine().schedule(self.latest_env_info().number)
+    }
+}

--- a/crates/ethcore/src/client/io.rs
+++ b/crates/ethcore/src/client/io.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::{Arc, atomic::AtomicI64};
+use std::sync::{atomic::AtomicI64, Arc};
 
 use super::Client;
 use crate::{

--- a/crates/ethcore/src/client/io.rs
+++ b/crates/ethcore/src/client/io.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::{atomic::AtomicI64, Arc};
-
 use super::Client;
 use crate::{
     error::{BlockError, ErrorKind, EthcoreResult, ImportErrorKind, QueueErrorKind},

--- a/crates/ethcore/src/client/io.rs
+++ b/crates/ethcore/src/client/io.rs
@@ -1,0 +1,148 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::{Arc, atomic::AtomicI64};
+
+use super::Client;
+use crate::{
+    error::{BlockError, ErrorKind, EthcoreResult, ImportErrorKind, QueueErrorKind},
+    types::transaction::UnverifiedTransaction,
+    verification::queue::kind::blocks::Unverified,
+};
+use blockchain::BlockProvider;
+use bytes::Bytes;
+use client::info::BlockInfo;
+use ethereum_types::H256;
+use miner::MinerService;
+use verification::queue::kind::BlockLike;
+
+const ANCIENT_BLOCKS_QUEUE_SIZE: usize = 4096;
+
+/// IO operations that should off-load heavy work to another thread.
+pub trait IoClient: Sync + Send {
+    /// Queue transactions for importing.
+    fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: usize);
+
+    /// Queue block import with transaction receipts. Does no sealing and transaction validation.
+    fn queue_ancient_block(
+        &self,
+        block_bytes: Unverified,
+        receipts_bytes: Bytes,
+    ) -> EthcoreResult<H256>;
+
+    /// Return percentage of how full is queue that handles ancient blocks. 0 if empty, 1 if full.
+    fn ancient_block_queue_fullness(&self) -> f32;
+
+    /// Queue conensus engine message.
+    fn queue_consensus_message(&self, message: Bytes);
+}
+
+impl IoClient for Client {
+    fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: usize) {
+        trace_time!("queue_transactions");
+        let len = transactions.len();
+        self.queue_transactions
+            .queue(&self.io_channel.read(), len, move |client| {
+                trace_time!("import_queued_transactions");
+                let best_block_number = client.best_block_header().number();
+                let txs: Vec<UnverifiedTransaction> = transactions
+                    .iter()
+                    .filter_map(|bytes| {
+                        client
+                            .engine()
+                            .decode_transaction(bytes, best_block_number)
+                            .ok()
+                    })
+                    .collect();
+
+                client.notify(|notify| {
+                    notify.transactions_received(&txs, peer_id);
+                });
+
+                client
+                    .importer
+                    .miner
+                    .import_external_transactions(client, txs);
+            })
+            .unwrap_or_else(|e| {
+                debug!(target: "client", "Ignoring {} transactions: {}", len, e);
+            });
+    }
+
+    fn queue_ancient_block(
+        &self,
+        unverified: Unverified,
+        receipts_bytes: Bytes,
+    ) -> EthcoreResult<H256> {
+        trace_time!("queue_ancient_block");
+
+        let hash = unverified.hash();
+        {
+            // check block order
+            if self.chain.read().is_known(&hash) {
+                bail!(ErrorKind::Import(ImportErrorKind::AlreadyInChain));
+            }
+            let parent_hash = unverified.parent_hash();
+            // NOTE To prevent race condition with import, make sure to check queued blocks first
+            // (and attempt to acquire lock)
+            let is_parent_pending = self.queued_ancient_blocks.read().contains(&parent_hash);
+            if !is_parent_pending && !self.chain.read().is_known(&parent_hash) {
+                bail!(ErrorKind::Block(BlockError::UnknownParent(parent_hash)));
+            }
+        }
+
+        // we queue blocks here and trigger an Executer.
+        {
+            let mut queued = self.queued_ancient_blocks.write();
+            queued.insert(hash);
+        }
+
+        // see content of executer in Client::new()
+        match self.queued_ancient_blocks_executer.lock().as_ref() {
+            Some(queue) => {
+                if !queue.enqueue((unverified, receipts_bytes)) {
+                    bail!(ErrorKind::Queue(QueueErrorKind::Full(
+                        ANCIENT_BLOCKS_QUEUE_SIZE
+                    )));
+                }
+            }
+            None => (),
+        }
+        Ok(hash)
+    }
+
+    fn ancient_block_queue_fullness(&self) -> f32 {
+        match self.queued_ancient_blocks_executer.lock().as_ref() {
+            Some(queue) => queue.len() as f32 / ANCIENT_BLOCKS_QUEUE_SIZE as f32,
+            None => 1.0, //return 1.0 if queue is not set
+        }
+    }
+
+    fn queue_consensus_message(&self, message: Bytes) {
+        match self
+            .queue_consensus_message
+            .queue(&self.io_channel.read(), 1, move |client| {
+                if let Err(e) = client.engine().handle_message(&message) {
+                    debug!(target: "poa", "Invalid message received: {}", e);
+                }
+            }) {
+            Ok(_) => (),
+            Err(e) => {
+                debug!(target: "poa", "Ignoring the message, error queueing: {}", e);
+            }
+        }
+    }
+}

--- a/crates/ethcore/src/client/mod.rs
+++ b/crates/ethcore/src/client/mod.rs
@@ -27,13 +27,17 @@ mod io_message;
 pub mod test_client;
 mod trace;
 
-// client components
-pub mod blockchain;
-pub mod call;
-pub mod importer;
+// internal client components
+mod call;
+mod importer;
+mod io;
+mod prometheus;
+
+/// types like block, tx, chain info.
 pub mod info;
-pub mod io;
-pub mod prometheus;
+
+/// types describing a blockchain client
+pub mod blockchain;
 
 #[cfg(any(test, feature = "test-helpers"))]
 pub use self::evm_test_client::{EvmTestClient, EvmTestError, TransactErr, TransactSuccess};

--- a/crates/ethcore/src/client/mod.rs
+++ b/crates/ethcore/src/client/mod.rs
@@ -27,21 +27,30 @@ mod io_message;
 pub mod test_client;
 mod trace;
 
+// client components
+pub mod blockchain;
+pub mod call;
+pub mod importer;
+pub mod info;
+pub mod io;
+pub mod prometheus;
+
 #[cfg(any(test, feature = "test-helpers"))]
 pub use self::evm_test_client::{EvmTestClient, EvmTestError, TransactErr, TransactSuccess};
 #[cfg(any(test, feature = "test-helpers"))]
 pub use self::test_client::{EachBlockWith, TestBlockChainClient};
 pub use self::{
+    blockchain::{BlockChainClient, BlockChainReset},
     chain_notify::{ChainMessageType, ChainNotify, ChainRoute, ChainRouteType, NewBlocks},
     client::*,
-    config::{BlockChainConfig, ClientConfig, DatabaseCompactionProfile, Mode, VMType},
+    config::{BlockChainConfig, ClientConfig, DatabaseCompactionProfile, VMType},
+    info::{BlockChain, BlockInfo, ChainInfo, EngineInfo, ScheduleInfo, TransactionInfo},
+    io::IoClient,
     io_message::ClientIoMessage,
     traits::{
-        AccountData, BadBlocks, Balance, BlockChain, BlockChainClient, BlockChainReset, BlockInfo,
-        BlockProducer, BroadcastProposalBlock, Call, ChainInfo, EngineClient, EngineInfo,
-        ImportBlock, ImportExportBlocks, ImportSealedBlock, IoClient, Nonce, PrepareOpenBlock,
-        ProvingBlockChainClient, ReopenBlock, ScheduleInfo, SealedBlockImporter, StateClient,
-        StateOrBlock, TransactionInfo,
+        AccountData, BadBlocks, Balance, BlockProducer, BroadcastProposalBlock, Call, EngineClient,
+        ImportBlock, ImportExportBlocks, ImportSealedBlock, Nonce, PrepareOpenBlock, ReopenBlock,
+        SealedBlockImporter, StateClient, StateOrBlock,
     },
 };
 pub use state::StateInfo;

--- a/crates/ethcore/src/client/prometheus.rs
+++ b/crates/ethcore/src/client/prometheus.rs
@@ -15,8 +15,7 @@
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::Client;
-use client::blockchain::BlockChainClient;
-use client::info::ChainInfo;
+use client::{blockchain::BlockChainClient, info::ChainInfo};
 use ethereum_types::U256;
 use stats::{PrometheusMetrics, PrometheusRegistry};
 

--- a/crates/ethcore/src/client/prometheus.rs
+++ b/crates/ethcore/src/client/prometheus.rs
@@ -1,0 +1,161 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::Client;
+use ethereum_types::U256;
+use client::blockchain::BlockChainClient;
+use client::info::ChainInfo;
+use stats::{PrometheusMetrics, PrometheusRegistry};
+
+impl PrometheusMetrics for Client {
+    fn prometheus_metrics(&self, r: &mut PrometheusRegistry) {
+        // gas, tx & blocks
+        let report = self.report();
+
+        for (key, value) in report.item_sizes.iter() {
+            r.register_gauge(
+                &key,
+                format!("Total item number of {}", key).as_str(),
+                *value as i64,
+            );
+        }
+
+        r.register_counter(
+            "import_gas",
+            "Gas processed",
+            report.gas_processed.as_u64() as i64,
+        );
+        r.register_counter(
+            "import_blocks",
+            "Blocks imported",
+            report.blocks_imported as i64,
+        );
+        r.register_counter(
+            "import_txs",
+            "Transactions applied",
+            report.transactions_applied as i64,
+        );
+
+        let state_db = self.state_db.read();
+        r.register_gauge(
+            "statedb_cache_size",
+            "State DB cache size",
+            state_db.cache_size() as i64,
+        );
+
+        // blockchain cache
+        let blockchain_cache_info = self.blockchain_cache_info();
+        r.register_gauge(
+            "blockchaincache_block_details",
+            "BlockDetails cache size",
+            blockchain_cache_info.block_details as i64,
+        );
+        r.register_gauge(
+            "blockchaincache_block_recipts",
+            "Block receipts size",
+            blockchain_cache_info.block_receipts as i64,
+        );
+        r.register_gauge(
+            "blockchaincache_blocks",
+            "Blocks cache size",
+            blockchain_cache_info.blocks as i64,
+        );
+        r.register_gauge(
+            "blockchaincache_txaddrs",
+            "Transaction addresses cache size",
+            blockchain_cache_info.transaction_addresses as i64,
+        );
+        r.register_gauge(
+            "blockchaincache_size",
+            "Total blockchain cache size",
+            blockchain_cache_info.total() as i64,
+        );
+
+        // chain info
+        let chain = self.chain_info();
+
+        let gap = chain
+            .ancient_block_number
+            .map(|x| U256::from(x + 1))
+            .and_then(|first| {
+                chain
+                    .first_block_number
+                    .map(|last| (first, U256::from(last)))
+            });
+        if let Some((first, last)) = gap {
+            r.register_gauge(
+                "chain_warpsync_gap_first",
+                "Warp sync gap, first block",
+                first.as_u64() as i64,
+            );
+            r.register_gauge(
+                "chain_warpsync_gap_last",
+                "Warp sync gap, last block",
+                last.as_u64() as i64,
+            );
+        }
+
+        r.register_gauge(
+            "chain_block",
+            "Best block number",
+            chain.best_block_number as i64,
+        );
+
+        // prunning info
+        let prunning = self.pruning_info();
+        r.register_gauge(
+            "prunning_earliest_chain",
+            "The first block which everything can be served after",
+            prunning.earliest_chain as i64,
+        );
+        r.register_gauge(
+            "prunning_earliest_state",
+            "The first block where state requests may be served",
+            prunning.earliest_state as i64,
+        );
+
+        // queue info
+        let queue = self.queue_info();
+        r.register_gauge(
+            "queue_mem_used",
+            "Queue heap memory used in bytes",
+            queue.mem_used as i64,
+        );
+        r.register_gauge(
+            "queue_size_total",
+            "The total size of the queues",
+            queue.total_queue_size() as i64,
+        );
+        r.register_gauge(
+            "queue_size_unverified",
+            "Number of queued items pending verification",
+            queue.unverified_queue_size as i64,
+        );
+        r.register_gauge(
+            "queue_size_verified",
+            "Number of verified queued items pending import",
+            queue.verified_queue_size as i64,
+        );
+        r.register_gauge(
+            "queue_size_verifying",
+            "Number of items being verified",
+            queue.verifying_queue_size as i64,
+        );
+
+        // database info
+        self.db.read().key_value().prometheus_metrics(r);
+    }
+}

--- a/crates/ethcore/src/client/prometheus.rs
+++ b/crates/ethcore/src/client/prometheus.rs
@@ -15,9 +15,9 @@
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::Client;
-use ethereum_types::U256;
 use client::blockchain::BlockChainClient;
 use client::info::ChainInfo;
+use ethereum_types::U256;
 use stats::{PrometheusMetrics, PrometheusRegistry};
 
 impl PrometheusMetrics for Client {

--- a/crates/ethcore/src/client/test_client.rs
+++ b/crates/ethcore/src/client/test_client.rs
@@ -59,12 +59,15 @@ use vm::Schedule;
 use block::{ClosedBlock, OpenBlock, SealedBlock};
 use call_contract::{CallContract, RegistryInfo};
 use client::{
+    blockchain::BlockChainClient,
+    blockchain::ProvingBlockChainClient,
+    io::IoClient,
     traits::{ForceUpdateSealing, TransactionRequest},
-    AccountData, BadBlocks, Balance, BlockChain, BlockChainClient, BlockChainInfo, BlockId,
-    BlockInfo, BlockProducer, BlockStatus, BroadcastProposalBlock, Call, CallAnalytics, ChainInfo,
-    EngineInfo, ImportBlock, ImportSealedBlock, IoClient, LastHashes, Mode, Nonce,
-    PrepareOpenBlock, ProvingBlockChainClient, ReopenBlock, ScheduleInfo, SealedBlockImporter,
-    StateClient, StateOrBlock, TraceFilter, TraceId, TransactionId, TransactionInfo, UncleId,
+    AccountData, BadBlocks, Balance, BlockChain, BlockChainInfo, BlockId, BlockInfo, BlockProducer,
+    BlockStatus, BroadcastProposalBlock, Call, CallAnalytics, ChainInfo, EngineInfo, ImportBlock,
+    ImportSealedBlock, LastHashes, Mode, Nonce, PrepareOpenBlock, ReopenBlock, ScheduleInfo,
+    SealedBlockImporter, StateClient, StateOrBlock, TraceFilter, TraceId, TransactionId,
+    TransactionInfo, UncleId,
 };
 use engines::EthEngine;
 use error::{Error, EthcoreResult};

--- a/crates/ethcore/src/client/test_client.rs
+++ b/crates/ethcore/src/client/test_client.rs
@@ -721,7 +721,7 @@ impl StateClient for TestBlockChainClient {
 }
 
 impl EngineInfo for TestBlockChainClient {
-    fn engine(&self) -> &dyn EthEngine {
+    fn engine(&self) -> Arc<dyn EthEngine> {
         unimplemented!()
     }
 }

--- a/crates/ethcore/src/client/test_client.rs
+++ b/crates/ethcore/src/client/test_client.rs
@@ -59,8 +59,7 @@ use vm::Schedule;
 use block::{ClosedBlock, OpenBlock, SealedBlock};
 use call_contract::{CallContract, RegistryInfo};
 use client::{
-    blockchain::BlockChainClient,
-    blockchain::ProvingBlockChainClient,
+    blockchain::{BlockChainClient, ProvingBlockChainClient},
     io::IoClient,
     traits::{ForceUpdateSealing, TransactionRequest},
     AccountData, BadBlocks, Balance, BlockChain, BlockChainInfo, BlockId, BlockInfo, BlockProducer,

--- a/crates/ethcore/src/client/traits.rs
+++ b/crates/ethcore/src/client/traits.rs
@@ -16,44 +16,24 @@
 
 //! Traits implemented by client.
 
-use std::{collections::BTreeMap, sync::Arc};
-
-use blockchain::{BlockReceipts, TreeRoute};
 use bytes::Bytes;
-use call_contract::{CallContract, RegistryInfo};
-use ethcore_miner::pool::VerifiedTransaction;
 use ethereum_types::{Address, H256, U256};
-use evm::Schedule;
-use itertools::Itertools;
-use kvdb::DBValue;
 use types::{
-    basic_account::BasicAccount,
-    block_status::BlockStatus,
-    blockchain_info::BlockChainInfo,
     call_analytics::CallAnalytics,
     data_format::DataFormat,
     encoded,
-    filter::Filter,
     header::Header,
     ids::*,
-    log_entry::LocalizedLogEntry,
-    pruning_info::PruningInfo,
-    receipt::LocalizedReceipt,
-    trace_filter::Filter as TraceFilter,
-    transaction::{self, Action, LocalizedTransaction, SignedTransaction},
+    transaction::{Action, SignedTransaction},
     BlockNumber,
 };
-use vm::LastHashes;
 
 use block::{ClosedBlock, OpenBlock, SealedBlock};
-use client::Mode;
-use engines::EthEngine;
 use error::{Error, EthcoreResult};
 use executed::CallError;
 use executive::Executed;
 use state::StateInfo;
-use trace::LocalizedTrace;
-use verification::queue::{kind::blocks::Unverified, QueueInfo as BlockQueueInfo};
+use verification::queue::kind::blocks::Unverified;
 
 use super::{blockchain::BlockChainClient, ChainInfo};
 

--- a/crates/ethcore/src/client/traits.rs
+++ b/crates/ethcore/src/client/traits.rs
@@ -55,6 +55,8 @@ use state::StateInfo;
 use trace::LocalizedTrace;
 use verification::queue::{kind::blocks::Unverified, QueueInfo as BlockQueueInfo};
 
+use super::{blockchain::BlockChainClient, ChainInfo};
+
 /// State information to be used during client query
 pub enum StateOrBlock {
     /// State to be used, may be pending
@@ -117,33 +119,6 @@ pub trait Balance {
 /// Provides methods to access account info
 pub trait AccountData: Nonce + Balance {}
 
-/// Provides `chain_info` method
-pub trait ChainInfo {
-    /// Get blockchain information.
-    fn chain_info(&self) -> BlockChainInfo;
-}
-
-/// Provides various information on a block by it's ID
-pub trait BlockInfo {
-    /// Get raw block header data by block id.
-    fn block_header(&self, id: BlockId) -> Option<encoded::Header>;
-
-    /// Get the best block header.
-    fn best_block_header(&self) -> Header;
-
-    /// Get raw block data by block header hash.
-    fn block(&self, id: BlockId) -> Option<encoded::Block>;
-
-    /// Get address code hash at given block's state.
-    fn code_hash(&self, address: &Address, id: BlockId) -> Option<H256>;
-}
-
-/// Provides various information on a transaction by it's ID
-pub trait TransactionInfo {
-    /// Get the hash of block that contains the transaction, if any.
-    fn transaction_block(&self, id: TransactionId) -> Option<H256>;
-}
-
 /// Provides methods to access chain state
 pub trait StateClient {
     /// Type representing chain state
@@ -159,9 +134,6 @@ pub trait StateClient {
     /// is unknown.
     fn state_at(&self, id: BlockId) -> Option<Self::State>;
 }
-
-/// Provides various blockchain information, like block header, chain state etc.
-pub trait BlockChain: ChainInfo + BlockInfo + TransactionInfo {}
 
 // FIXME Why these methods belong to BlockChainClient and not MiningBlockChainClient?
 /// Provides methods to import block into blockchain
@@ -202,249 +174,10 @@ pub trait Call {
     ) -> Result<U256, CallError>;
 }
 
-/// Provides `engine` method
-pub trait EngineInfo {
-    /// Get underlying engine object
-    fn engine(&self) -> &dyn EthEngine;
-}
-
-/// IO operations that should off-load heavy work to another thread.
-pub trait IoClient: Sync + Send {
-    /// Queue transactions for importing.
-    fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: usize);
-
-    /// Queue block import with transaction receipts. Does no sealing and transaction validation.
-    fn queue_ancient_block(
-        &self,
-        block_bytes: Unverified,
-        receipts_bytes: Bytes,
-    ) -> EthcoreResult<H256>;
-
-    /// Return percentage of how full is queue that handles ancient blocks. 0 if empty, 1 if full.
-    fn ancient_block_queue_fullness(&self) -> f32;
-
-    /// Queue conensus engine message.
-    fn queue_consensus_message(&self, message: Bytes);
-}
-
 /// Provides recently seen bad blocks.
 pub trait BadBlocks {
     /// Returns a list of blocks that were recently not imported because they were invalid.
     fn bad_blocks(&self) -> Vec<(Unverified, String)>;
-}
-
-/// Blockchain database client. Owns and manages a blockchain and a block queue.
-pub trait BlockChainClient:
-    Sync
-    + Send
-    + AccountData
-    + BlockChain
-    + CallContract
-    + RegistryInfo
-    + ImportBlock
-    + IoClient
-    + BadBlocks
-{
-    /// Look up the block number for the given block ID.
-    fn block_number(&self, id: BlockId) -> Option<BlockNumber>;
-
-    /// Get raw block body data by block id.
-    /// Block body is an RLP list of two items: uncles and transactions.
-    fn block_body(&self, id: BlockId) -> Option<encoded::Body>;
-
-    /// Get block status by block header hash.
-    fn block_status(&self, id: BlockId) -> BlockStatus;
-
-    /// Get block total difficulty.
-    fn block_total_difficulty(&self, id: BlockId) -> Option<U256>;
-
-    /// Attempt to get address storage root at given block.
-    /// May not fail on BlockId::Latest.
-    fn storage_root(&self, address: &Address, id: BlockId) -> Option<H256>;
-
-    /// Get block hash.
-    fn block_hash(&self, id: BlockId) -> Option<H256>;
-
-    /// Get address code at given block's state.
-    fn code(&self, address: &Address, state: StateOrBlock) -> Option<Option<Bytes>>;
-
-    /// Get address code at the latest block's state.
-    fn latest_code(&self, address: &Address) -> Option<Bytes> {
-        self.code(address, BlockId::Latest.into())
-            .expect("code will return Some if given BlockId::Latest; qed")
-    }
-
-    /// Returns true if the given block is known and in the canon chain.
-    fn is_canon(&self, hash: &H256) -> bool;
-
-    /// Get address code hash at given block's state.
-
-    /// Get value of the storage at given position at the given block's state.
-    ///
-    /// May not return None if given BlockId::Latest.
-    /// Returns None if and only if the block's root hash has been pruned from the DB.
-    fn storage_at(&self, address: &Address, position: &H256, state: StateOrBlock) -> Option<H256>;
-
-    /// Get value of the storage at given position at the latest block's state.
-    fn latest_storage_at(&self, address: &Address, position: &H256) -> H256 {
-        self.storage_at(address, position, BlockId::Latest.into())
-			.expect("storage_at will return Some if given BlockId::Latest. storage_at was given BlockId::Latest. \
-			Therefore storage_at has returned Some; qed")
-    }
-
-    /// Get a list of all accounts in the block `id`, if fat DB is in operation, otherwise `None`.
-    /// If `after` is set the list starts with the following item.
-    fn list_accounts(
-        &self,
-        id: BlockId,
-        after: Option<&Address>,
-        count: u64,
-    ) -> Option<Vec<Address>>;
-
-    /// Get a list of all storage keys in the block `id`, if fat DB is in operation, otherwise `None`.
-    /// If `after` is set the list starts with the following item.
-    fn list_storage(
-        &self,
-        id: BlockId,
-        account: &Address,
-        after: Option<&H256>,
-        count: u64,
-    ) -> Option<Vec<H256>>;
-
-    /// Get transaction with given hash.
-    fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction>;
-
-    /// Get uncle with given id.
-    fn uncle(&self, id: UncleId) -> Option<encoded::Header>;
-
-    /// Get transaction receipt with given hash.
-    fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt>;
-
-    /// Get localized receipts for all transaction in given block.
-    fn localized_block_receipts(&self, id: BlockId) -> Option<Vec<LocalizedReceipt>>;
-
-    /// Get a tree route between `from` and `to`.
-    /// See `BlockChain::tree_route`.
-    fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute>;
-
-    /// Get all possible uncle hashes for a block.
-    fn find_uncles(&self, hash: &H256) -> Option<Vec<H256>>;
-
-    /// Get block receipts data by block header hash.
-    fn block_receipts(&self, hash: &H256) -> Option<BlockReceipts>;
-
-    /// Get block queue information.
-    fn queue_info(&self) -> BlockQueueInfo;
-
-    /// Returns true if block queue is empty.
-    fn is_queue_empty(&self) -> bool {
-        self.queue_info().is_empty()
-    }
-
-    /// Clear block queue and abort all import activity.
-    fn clear_queue(&self);
-
-    /// Get the registrar address, if it exists.
-    fn additional_params(&self) -> BTreeMap<String, String>;
-
-    /// Returns logs matching given filter. If one of the filtering block cannot be found, returns the block id that caused the error.
-    fn logs(&self, filter: Filter) -> Result<Vec<LocalizedLogEntry>, BlockId>;
-
-    /// Replays a given transaction for inspection.
-    fn replay(&self, t: TransactionId, analytics: CallAnalytics) -> Result<Executed, CallError>;
-
-    /// Replays all the transactions in a given block for inspection.
-    fn replay_block_transactions(
-        &self,
-        block: BlockId,
-        analytics: CallAnalytics,
-    ) -> Result<Box<dyn Iterator<Item = (H256, Executed)>>, CallError>;
-
-    /// Returns traces matching given filter.
-    fn filter_traces(&self, filter: TraceFilter) -> Option<Vec<LocalizedTrace>>;
-
-    /// Returns trace with given id.
-    fn trace(&self, trace: TraceId) -> Option<LocalizedTrace>;
-
-    /// Returns traces created by transaction.
-    fn transaction_traces(&self, trace: TransactionId) -> Option<Vec<LocalizedTrace>>;
-
-    /// Returns traces created by transaction from block.
-    fn block_traces(&self, trace: BlockId) -> Option<Vec<LocalizedTrace>>;
-
-    /// Get last hashes starting from best block.
-    fn last_hashes(&self) -> LastHashes;
-
-    /// List all ready transactions that should be propagated to other peers.
-    fn transactions_to_propagate(&self) -> Vec<Arc<VerifiedTransaction>>;
-
-    /// Sorted list of transaction gas prices from at least last sample_size blocks.
-    fn gas_price_corpus(&self, sample_size: usize) -> ::stats::Corpus<U256> {
-        let mut h = self.chain_info().best_block_hash;
-        let mut corpus = Vec::new();
-        while corpus.is_empty() {
-            for _ in 0..sample_size {
-                let block = match self.block(BlockId::Hash(h)) {
-                    Some(block) => block,
-                    None => return corpus.into(),
-                };
-
-                if block.number() == 0 {
-                    return corpus.into();
-                }
-                block
-                    .transaction_views()
-                    .iter()
-                    .foreach(|t| corpus.push(t.gas_price()));
-                h = block.parent_hash().clone();
-            }
-        }
-        corpus.into()
-    }
-
-    /// Get the preferred chain ID to sign on
-    fn signing_chain_id(&self) -> Option<u64>;
-
-    /// Get the mode.
-    fn mode(&self) -> Mode;
-
-    /// Set the mode.
-    fn set_mode(&self, mode: Mode);
-
-    /// Get the chain spec name.
-    fn spec_name(&self) -> String;
-
-    /// Set the chain via a spec name.
-    fn set_spec_name(&self, spec_name: String) -> Result<(), ()>;
-
-    /// Disable the client from importing blocks. This cannot be undone in this session and indicates
-    /// that a subsystem has reason to believe this executable incapable of syncing the chain.
-    fn disable(&self);
-
-    /// Returns engine-related extra info for `BlockId`.
-    fn block_extra_info(&self, id: BlockId) -> Option<BTreeMap<String, String>>;
-
-    /// Returns engine-related extra info for `UncleId`.
-    fn uncle_extra_info(&self, id: UncleId) -> Option<BTreeMap<String, String>>;
-
-    /// Returns information about pruning/data availability.
-    fn pruning_info(&self) -> PruningInfo;
-
-    /// Returns a transaction signed with the key configured in the engine signer.
-    fn create_transaction(
-        &self,
-        tx_request: TransactionRequest,
-    ) -> Result<SignedTransaction, transaction::Error>;
-
-    /// Schedule state-altering transaction to be executed on the next pending
-    /// block with the given gas and nonce parameters.
-    fn transact(&self, tx_request: TransactionRequest) -> Result<(), transaction::Error>;
-
-    /// Get the address of the registry itself.
-    fn registrar_address(&self) -> Option<Address>;
-
-    /// Returns true, if underlying import queue is processing possible fork at the moment
-    fn is_processing_fork(&self) -> bool;
 }
 
 /// The data required for a `Client` to create a transaction.
@@ -516,12 +249,6 @@ pub trait PrepareOpenBlock {
 /// Provides methods used for sealing new state
 pub trait BlockProducer: PrepareOpenBlock + ReopenBlock {}
 
-/// Provides `latest_schedule` method
-pub trait ScheduleInfo {
-    /// Returns latest schedule.
-    fn latest_schedule(&self) -> Schedule;
-}
-
 ///Provides `import_sealed_block` method
 pub trait ImportSealedBlock {
     /// Import sealed block. Skips all verifications.
@@ -572,38 +299,6 @@ pub trait EngineClient: Sync + Send + ChainInfo {
 
     /// Get raw block header data by block id.
     fn block_header(&self, id: BlockId) -> Option<encoded::Header>;
-}
-
-/// Extended client interface for providing proofs of the state.
-pub trait ProvingBlockChainClient: BlockChainClient {
-    /// Prove account storage at a specific block id.
-    ///
-    /// Both provided keys assume a secure trie.
-    /// Returns a vector of raw trie nodes (in order from the root) proving the storage query.
-    fn prove_storage(&self, key1: H256, key2: H256, id: BlockId) -> Option<(Vec<Bytes>, H256)>;
-
-    /// Prove account existence at a specific block id.
-    /// The key is the keccak hash of the account's address.
-    /// Returns a vector of raw trie nodes (in order from the root) proving the query.
-    fn prove_account(&self, key1: H256, id: BlockId) -> Option<(Vec<Bytes>, BasicAccount)>;
-
-    /// Prove execution of a transaction at the given block.
-    /// Returns the output of the call and a vector of database items necessary
-    /// to reproduce it.
-    fn prove_transaction(
-        &self,
-        transaction: SignedTransaction,
-        id: BlockId,
-    ) -> Option<(Bytes, Vec<DBValue>)>;
-
-    /// Get an epoch change signal by block hash.
-    fn epoch_signal(&self, hash: H256) -> Option<Vec<u8>>;
-}
-
-/// resets the blockchain
-pub trait BlockChainReset {
-    /// reset to best_block - n
-    fn reset(&self, num: u32) -> Result<(), String>;
 }
 
 /// Provides a method for importing/exporting blocks

--- a/crates/ethcore/src/miner/miner.rs
+++ b/crates/ethcore/src/miner/miner.rs
@@ -58,8 +58,8 @@ use block::{ClosedBlock, SealedBlock};
 use client::{
     info::BlockChain,
     traits::{EngineClient, ForceUpdateSealing},
-    BlockId, BlockProducer, ChainInfo, ClientIoMessage, Nonce, SealedBlockImporter,
-    TransactionId, TransactionInfo,
+    BlockId, BlockProducer, ChainInfo, ClientIoMessage, Nonce, SealedBlockImporter, TransactionId,
+    TransactionInfo,
 };
 use engines::{EngineSigner, EthEngine, Seal, SealingState};
 use error::{Error, ErrorKind};

--- a/crates/ethcore/src/miner/miner.rs
+++ b/crates/ethcore/src/miner/miner.rs
@@ -56,8 +56,9 @@ use using_queue::{GetAction, UsingQueue};
 
 use block::{ClosedBlock, SealedBlock};
 use client::{
+    info::BlockChain,
     traits::{EngineClient, ForceUpdateSealing},
-    BlockChain, BlockId, BlockProducer, ChainInfo, ClientIoMessage, Nonce, SealedBlockImporter,
+    BlockId, BlockProducer, ChainInfo, ClientIoMessage, Nonce, SealedBlockImporter,
     TransactionId, TransactionInfo,
 };
 use engines::{EngineSigner, EthEngine, Seal, SealingState};

--- a/crates/ethcore/src/miner/mod.rs
+++ b/crates/ethcore/src/miner/mod.rs
@@ -50,7 +50,8 @@ use types::{
 use block::SealedBlock;
 use call_contract::{CallContract, RegistryInfo};
 use client::{
-    traits::ForceUpdateSealing, AccountData, BlockChain, BlockProducer, ChainInfo, Nonce,
+    info::BlockChain,
+    traits::ForceUpdateSealing, AccountData, BlockProducer, ChainInfo, Nonce,
     ScheduleInfo, SealedBlockImporter,
 };
 use error::Error;

--- a/crates/ethcore/src/miner/mod.rs
+++ b/crates/ethcore/src/miner/mod.rs
@@ -50,8 +50,7 @@ use types::{
 use block::SealedBlock;
 use call_contract::{CallContract, RegistryInfo};
 use client::{
-    info::BlockChain,
-    traits::ForceUpdateSealing, AccountData, BlockProducer, ChainInfo, Nonce,
+    info::BlockChain, traits::ForceUpdateSealing, AccountData, BlockProducer, ChainInfo, Nonce,
     ScheduleInfo, SealedBlockImporter,
 };
 use error::Error;

--- a/crates/ethcore/src/snapshot/tests/proof_of_authority.rs
+++ b/crates/ethcore/src/snapshot/tests/proof_of_authority.rs
@@ -19,7 +19,7 @@
 use std::{cell::RefCell, str::FromStr, sync::Arc};
 
 use accounts::AccountProvider;
-use client::{BlockChainClient, ChainInfo, Client};
+use client::{blockchain::BlockChainClient, ChainInfo, Client};
 use crypto::publickey::Secret;
 use snapshot::tests::helpers as snapshot_helpers;
 use spec::Spec;

--- a/crates/ethcore/src/tests/client.rs
+++ b/crates/ethcore/src/tests/client.rs
@@ -20,10 +20,9 @@ use std::{
 };
 
 use client::{
-    traits::{
-        BlockChainClient, BlockChainReset, BlockInfo, ChainInfo, ImportBlock, ImportExportBlocks,
-    },
-    Client, ClientConfig, ImportSealedBlock, PrepareOpenBlock,
+    blockchain::{BlockChainClient, BlockChainReset},
+    info::{BlockInfo, ChainInfo},
+    Client, ClientConfig, ImportBlock, ImportExportBlocks, ImportSealedBlock, PrepareOpenBlock,
 };
 use crypto::publickey::KeyPair;
 use ethereum;
@@ -417,7 +416,7 @@ fn does_not_propagate_delayed_transactions() {
 
 #[test]
 fn transaction_proof() {
-    use client::ProvingBlockChainClient;
+    use client::blockchain::ProvingBlockChainClient;
 
     let client = generate_dummy_client(0);
     let address = Address::random();

--- a/crates/rpc/src/v1/impls/eth.rs
+++ b/crates/rpc/src/v1/impls/eth.rs
@@ -28,8 +28,8 @@ use parking_lot::Mutex;
 use ethash::{self, SeedHashCompute};
 use ethcore::{
     client::{
-        BlockChainClient, BlockId, Call, EngineInfo, ProvingBlockChainClient, StateClient,
-        StateInfo, StateOrBlock, TransactionId, UncleId,
+        blockchain::ProvingBlockChainClient, BlockChainClient, BlockId, Call, EngineInfo,
+        StateClient, StateInfo, StateOrBlock, TransactionId, UncleId,
     },
     miner::{self, MinerService},
     snapshot::SnapshotService,

--- a/crates/rpc/src/v1/tests/helpers/miner_service.rs
+++ b/crates/rpc/src/v1/tests/helpers/miner_service.rs
@@ -110,7 +110,7 @@ impl StateClient for TestMinerService {
 }
 
 impl EngineInfo for TestMinerService {
-    fn engine(&self) -> &dyn EthEngine {
+    fn engine(&self) -> Arc<dyn EthEngine> {
         unimplemented!()
     }
 }

--- a/crates/vm/evm/benches/basic.rs
+++ b/crates/vm/evm/benches/basic.rs
@@ -33,7 +33,7 @@ use criterion::{black_box, Bencher, Criterion};
 use ethereum_types::{Address, U256};
 use evm::Factory;
 use rustc_hex::FromHex;
-use std::{collections::BTreeMap, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 use vm::{tests::FakeExt, ActionParams, Ext, GasLeft, Result};
 
 criterion_group!(


### PR DESCRIPTION
This change is the first in the series of refactoring the client object into a set of smaller managable pieces, the guidelines for those changes are:

  - Completely get rid if the `ethcore::client::traits` module and organize the traits defined there by their function rather than the type of language construct they are.
  - There are around 10+ different types called `BlockChain` encountered so far during this refactoring session. Reduce them to one.
  - Completely get rid of the `Client` struct and split its functionality into componentized types that interact with each other - preferably through message passing in an agent architecture.

In this first stab of splitting the `client.rs` file into smaller files I have made some internal member variables public so they are accessible from within other files. This will change with time, it's a temporary remedy.

*This change does not change any functional behavior of the code and the system should just work as it worked before.*