### PR TITLE
EIP-2929: only add params.address to access list

### DIFF
--- a/crates/ethcore/src/executive.rs
+++ b/crates/ethcore/src/executive.rs
@@ -240,7 +240,6 @@ impl<'a> CallCreateExecutive<'a> {
         if schedule.eip2929 {
             let mut substate = Substate::from_access_list(&params.access_list);
             substate.access_list.insert_address(params.address);
-            substate.access_list.insert_address(params.sender);
             substate
         } else {
             Substate::default()


### PR DESCRIPTION
No matter if this is actually the issue for #354, it looks like a deviation from the specification nontheless. The spec only specify that we add the target address to the access list, but never mentioned `params.sender`.