### PR TITLE
Berlin HF on POA Core and Sokol

### DIFF
--- a/crates/ethcore/res/chainspec/poacore.json
+++ b/crates/ethcore/res/chainspec/poacore.json
@@ -45,7 +45,9 @@
 		"eip1344Transition": 12598600,
 		"eip1706Transition": 12598600,
 		"eip1884Transition": 12598600,
-		"eip2028Transition": 12598600
+		"eip2028Transition": 12598600,
+		"eip2929Transition": 21364900,
+		"eip2930Transition": 21364900
 	},
 	"genesis": {
 		"seal": {
@@ -75,6 +77,12 @@
 							"modexp": {
 								"divisor": 20
 							}
+						}
+					},
+					"21364900": {
+						"info": "EIP-2565: ModExp Gas Cost. Berlin hardfork (May 24, 2021, ~10:00 am UTC)",
+						"price": {
+							"modexp2565": {}
 						}
 					}
 				}

--- a/crates/ethcore/res/chainspec/poasokol.json
+++ b/crates/ethcore/res/chainspec/poasokol.json
@@ -50,7 +50,9 @@
 		"eip1344Transition": 12095200,
 		"eip1706Transition": 12095200,
 		"eip1884Transition": 12095200,
-		"eip2028Transition": 12095200
+		"eip2028Transition": 12095200,
+		"eip2929Transition": 21050600,
+		"eip2930Transition": 21050600
 	},
 	"genesis": {
 		"seal": {
@@ -78,6 +80,12 @@
 							"modexp": {
 								"divisor": 20
 							}
+						}
+					},
+					"21050600": {
+						"info": "EIP-2565: ModExp Gas Cost. Berlin hardfork (May 24, 2021, ~10:00 am UTC)",
+						"price": {
+							"modexp2565": {}
 						}
 					}
 				}


### PR DESCRIPTION
We are going to activate Berlin HF on POA Core and Sokol at ~10:00 am UTC, May 24. Block number for `POA Core` is  `21364900`. Block number for `POA Sokol` is `21050600`.