### PR TITLE
gasPrice is required field for Transaction object

### DIFF
--- a/crates/rpc/src/v1/impls/debug.rs
+++ b/crates/rpc/src/v1/impls/debug.rs
@@ -52,6 +52,7 @@ impl<C: BlockChainClient + 'static> Debug for DebugClient<C> {
             .map(|(block, reason)| {
                 let number = block.header.number();
                 let hash = block.header.hash();
+                let base_fee = block.header.base_fee();
                 RichBlock {
                     inner: Block {
                         hash: Some(hash),
@@ -76,7 +77,7 @@ impl<C: BlockChainClient + 'static> Debug for DebugClient<C> {
                             .cloned()
                             .map(Into::into)
                             .collect(),
-                        base_fee_per_gas: block.header.base_fee(),
+                        base_fee_per_gas: base_fee,
                         uncles: block.uncles.iter().map(Header::hash).collect(),
                         transactions: BlockTransactions::Full(
                             block
@@ -84,13 +85,16 @@ impl<C: BlockChainClient + 'static> Debug for DebugClient<C> {
                                 .into_iter()
                                 .enumerate()
                                 .map(|(transaction_index, signed)| {
-                                    Transaction::from_localized(LocalizedTransaction {
-                                        block_number: number,
-                                        block_hash: hash,
-                                        transaction_index,
-                                        signed,
-                                        cached_sender: None,
-                                    })
+                                    Transaction::from_localized(
+                                        LocalizedTransaction {
+                                            block_number: number,
+                                            block_hash: hash,
+                                            transaction_index,
+                                            signed,
+                                            cached_sender: None,
+                                        },
+                                        base_fee,
+                                    )
                                 })
                                 .collect(),
                         ),

--- a/crates/rpc/src/v1/types/block.rs
+++ b/crates/rpc/src/v1/types/block.rs
@@ -229,7 +229,7 @@ mod tests {
         let serialized = serde_json::to_string(&t).unwrap();
         assert_eq!(
             serialized,
-            r#"[{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","blockHash":null,"blockNumber":null,"transactionIndex":null,"from":"0x0000000000000000000000000000000000000000","to":null,"value":"0x0","gas":"0x0","input":"0x","creates":null,"raw":"0x","publicKey":null,"chainId":null,"v":"0x0","r":"0x0","s":"0x0","condition":null}]"#
+            r#"[{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","blockHash":null,"blockNumber":null,"transactionIndex":null,"from":"0x0000000000000000000000000000000000000000","to":null,"value":"0x0","gasPrice":"0x0","gas":"0x0","input":"0x","creates":null,"raw":"0x","publicKey":null,"chainId":null,"v":"0x0","r":"0x0","s":"0x0","condition":null}]"#
         );
 
         let t = BlockTransactions::Hashes(vec![H256::default().into()]);


### PR DESCRIPTION
gasPrice field of Transaction object is made required according to the spec:
https://github.com/ethereum/eth1.0-specs/pull/251

For 1559 transactions, gasPrice is equal to effective_gas_price for transactions that can be observed within a block context. For 1559 transactions still not mined, gasPrice is equal to maxFeePerGas.