### PR TITLE
[vm/builtin] Fix Cargo config

### DIFF
--- a/crates/vm/builtin/Cargo.toml
+++ b/crates/vm/builtin/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-bn = { git = "https://github.com/paritytech/bn", default-features = false }
+substrate-bn = { git = "https://github.com/paritytech/bn", default-features = false }
 byteorder = "1.3.2"
 eip-152 = { path = "../../util/EIP-152" }
 ethereum-types = "0.9.2"


### PR DESCRIPTION
`bn` has been renamed to `substrate-bn`

See: https://github.com/paritytech/bn/commit/47d6e4f91918db51a65fb428e4c3d39de4a96d11