### PR TITLE
Fix a mistake in eth protocol implementation

### DIFF
--- a/crates/ethcore/sync/src/chain/requester.rs
+++ b/crates/ethcore/sync/src/chain/requester.rs
@@ -124,7 +124,7 @@ impl SyncRequester {
             io,
             peer_id,
             PeerAsking::PooledTransactions,
-            PooledTransactionsPacket,
+            GetPooledTransactionsPacket,
             rlp.out(),
         )
     }


### PR DESCRIPTION
`GetPooledTransaction (0x9)` requests were sent with a wrong packet id of `PooledTransaction (0xa)` instead. This led to OpenEthereum nodes being dropped by their peers, see https://github.com/ledgerwatch/erigon/issues/2542. It is also a potential cause for issue #508.