### PR TITLE
Specified that you can't use Visual Studio 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We recommend installing Rust through [rustup](https://www.rustup.rs/). If you do
   `clang` is required. It comes with Xcode command line tools or can be installed with homebrew.
 
 - Windows:
-  Make sure you have Visual Studio 2015 with C++ support installed. Next, download and run the `rustup` installer from
+  Make sure you have Visual Studio 2015 with C++ support installed (Visual Studio 2019 not supported). Next, download and run the `rustup` installer from
   https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe, start "VS2015 x64 Native Tools Command Prompt", and use the following command to install and set up the `msvc` toolchain:
   ```bash
   $ rustup default stable-x86_64-pc-windows-msvc


### PR DESCRIPTION
I know it says have 2015 but, I just assumed that if 2015 worked then so did 2019. I know it's not super important, but it took me a while to find this [issue](https://github.com/openethereum/parity-ethereum/issues/10715)