### PR TITLE
Fix evmbin build

### DIFF
--- a/crates/ethcore/src/client/test_client.rs
+++ b/crates/ethcore/src/client/test_client.rs
@@ -1090,6 +1090,10 @@ impl BlockChainClient for TestBlockChainClient {
         }
         None
     }
+
+    fn is_aura(&self) -> bool {
+        false
+    }
 }
 
 impl IoClient for TestBlockChainClient {


### PR DESCRIPTION
Implements missing trait function `BlockChainClient::is_aura()` for `TestBlockChainClient`.