### PR TITLE
fix compiling error with rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+    channel = "1.51.0"


### PR DESCRIPTION
Add `rust-toolchain.toml`, fixes build error E0061 while trying to compile with newer than 1.52.0 toolchains.