### PR TITLE
limit codegen-units to get the maximum optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ opt-level = 3 # makes tests slower to compile, but faster to run
 [profile.release]
 debug = false
 lto = true
+codegen-units = 1
 
 [workspace]
 # This should only list projects that are not


### PR DESCRIPTION
Hello,

There might be a performance regression due to enabling `lto` without limiting the number of code generation units (`codegen-units = 1`).

References:
https://github.com/rust-lang/rust/issues/47745
https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units