### PR TITLE
concensus/miner: fix double read-lock of options

### DIFF
--- a/crates/concensus/miner/src/pool/queue.rs
+++ b/crates/concensus/miner/src/pool/queue.rs
@@ -709,8 +709,8 @@ impl TransactionQueue {
                 .signed()
                 .effective_gas_price(self.options.read().block_base_fee),
             None => {
-                self.options.read().minimal_gas_price
-                    + self.options.read().block_base_fee.unwrap_or_default()
+                let options = self.options.read();
+                options.minimal_gas_price + options.block_base_fee.unwrap_or_default()
             }
         }
     }


### PR DESCRIPTION
`options` is `parkingLot::RwLock`.

https://docs.rs/parking_lot/latest/parking_lot/type.RwLock.html
> Attempts to recursively acquire a read lock within a single thread may result in a deadlock.

The fix locks once and reuses the results.