### PR TITLE
crates/accounts: fix conflicting lock orders

### DIFF
--- a/crates/accounts/src/lib.rs
+++ b/crates/accounts/src/lib.rs
@@ -447,9 +447,11 @@ impl AccountProvider {
         message: Message,
     ) -> Result<Signature, SignError> {
         let account = self.sstore.account_ref(&address)?;
-        match self.unlocked_secrets.read().get(&account) {
+        let secrets = self.unlocked_secrets.read();
+        match secrets.get(&account) {
             Some(secret) => Ok(self.sstore.sign_with_secret(&secret, &message)?),
             None => {
+                std::mem::drop(secrets);
                 let password = password
                     .map(Ok)
                     .unwrap_or_else(|| self.password(&account))?;


### PR DESCRIPTION
`unlocked_secrets` and `unlocked` are `parking_lot::RwLock`.
In fn `sign()`, `unlocked_secrets.read()` -> `password()` -> `unlocked.write()`.
https://github.com/openethereum/openethereum/blob/6a42062adf463f33699f9dd60926ef803687aabd/crates/accounts/src/lib.rs#L449-L455
https://github.com/openethereum/openethereum/blob/6a42062adf463f33699f9dd60926ef803687aabd/crates/accounts/src/lib.rs#L372-L373

There are two other cases where `unlocked` is locked before `unlocked_secrets`.
If they are concurrent with the above case, a deadlock may happen.
1. https://github.com/openethereum/openethereum/blob/6a42062adf463f33699f9dd60926ef803687aabd/crates/accounts/src/lib.rs#L420-L422
2. https://github.com/openethereum/openethereum/blob/6a42062adf463f33699f9dd60926ef803687aabd/crates/accounts/src/lib.rs#L343-L354

The fix is to assign `unlocked_secrets.read()` to a variable `secrets` and explicitly drop it before calling `password()`.